### PR TITLE
ci: add ADR-29 admission fan-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,24 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 jobs:
+  risk-classification:
+    name: risk-classification/pass
+    runs-on: [self-hosted, sylphx, linux, standard]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: ADR-29 risk classification
+        uses: SylphxAI/.github/.github/actions/adr29-admission@main
+        with:
+          mode: classify
+          policy-mode: observe
+
   ci:
     runs-on: [self-hosted, sylphx, linux, standard]
     steps:
@@ -40,3 +57,18 @@ jobs:
 
       - name: Test
         run: bun test
+
+  trunk-admission:
+    name: trunk-admission/pass
+    runs-on: [self-hosted, sylphx, linux, standard]
+    needs:
+      - risk-classification
+      - ci
+    if: ${{ !cancelled() }}
+    steps:
+      - name: ADR-29 trunk admission
+        uses: SylphxAI/.github/.github/actions/adr29-admission@main
+        with:
+          mode: fan-in
+          policy-mode: observe
+          upstream-results-json: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- add the ADR-29 risk-classification/pass observe-mode gate
- add the trunk-admission/pass fan-in gate over risk classification and the existing ci job
- keep the existing ci job in place so branch protection can migrate only after PR and merge_group evidence exists

## Validation
- ruby YAML parse for .github/workflows/ci.yml
- git diff --check
- actionlint .github/workflows/ci.yml with the existing SylphxAI self-hosted runner labels ignored