### PR TITLE
ci: add ADR-29 postsubmit recovery gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,9 @@ jobs:
   ci:
     runs-on: [self-hosted, sylphx, linux, standard]
     env:
-      CARGO_HOME: /tmp/synth-cargo-${{ github.run_id }}-${{ github.run_attempt }}
-      RUSTUP_HOME: /tmp/synth-rustup-${{ github.run_id }}-${{ github.run_attempt }}
+      SYNTH_RUST_HOME: /tmp/synth-rust-${{ github.run_id }}-${{ github.run_attempt }}
+      CARGO_HOME: /tmp/synth-rust-${{ github.run_id }}-${{ github.run_attempt }}/.cargo
+      RUSTUP_HOME: /tmp/synth-rust-${{ github.run_id }}-${{ github.run_attempt }}/.rustup
     steps:
       - uses: actions/checkout@v4
 
@@ -38,13 +39,16 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Prepare isolated Rust home
+        run: |
+          mkdir -p "$SYNTH_RUST_HOME" "$CARGO_HOME" "$RUSTUP_HOME"
+          echo "HOME=$SYNTH_RUST_HOME" >> "$GITHUB_ENV"
+          echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-
-      - name: Add isolated Cargo bin to PATH
-        run: echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -56,7 +60,7 @@ jobs:
         run: bun run lint
 
       - name: Build
-        run: bun run build
+        run: bunx turbo build --concurrency=1
 
       - name: Type check
         run: bun run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,40 @@ jobs:
           mode: fan-in
           policy-mode: observe
           upstream-results-json: ${{ toJSON(needs) }}
+
+  postsubmit-proof:
+    name: postsubmit-proof/pass
+    runs-on: [self-hosted, sylphx, linux, standard]
+    needs:
+      - risk-classification
+      - ci
+      - trunk-admission
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled() }}
+    steps:
+      - name: ADR-29 postsubmit proof
+        uses: SylphxAI/.github/.github/actions/adr29-admission@main
+        with:
+          mode: postsubmit-proof
+          policy-mode: enforce
+          upstream-results-json: ${{ toJSON(needs) }}
+
+  recovery-decision:
+    name: recovery-decision/pass
+    runs-on: [self-hosted, sylphx, linux, standard]
+    needs:
+      - risk-classification
+      - ci
+      - trunk-admission
+      - postsubmit-proof
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.postsubmit-proof.result != 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: ADR-29 recovery decision
+        uses: SylphxAI/.github/.github/actions/adr29-admission@main
+        with:
+          mode: recovery-decision
+          policy-mode: observe
+          upstream-results-json: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
 
   ci:
     runs-on: [self-hosted, sylphx, linux, standard]
+    env:
+      CARGO_HOME: /tmp/synth-cargo-${{ github.run_id }}-${{ github.run_attempt }}
+      RUSTUP_HOME: /tmp/synth-rustup-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v4
 
@@ -39,6 +42,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+
+      - name: Add isolated Cargo bin to PATH
+        run: echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh


### PR DESCRIPTION
## Summary
- add `postsubmit-proof/pass` on `push` to `main`, fanning in `risk-classification`, raw `ci`, and `trunk-admission`
- add conditional `recovery-decision/pass` so a failed postsubmit proof still emits a structured ADR-29 recovery decision

## Validation
- YAML parse of `.github/workflows/ci.yml`
- `actionlint` on `.github/workflows/ci.yml`
- `git diff --check`
- doctrine audit on this branch: `postsubmit_recovery_status=PRESENT`

## Risk
CI/governance-only. PR and merge-queue required contexts remain `risk-classification/pass` and `trunk-admission/pass`; postsubmit proof runs only on `push` to `main`.