### PR TITLE
ci: retry Rust dependency prefetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,26 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
+          components: rustfmt, clippy
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Pre-fetch Rust dependencies
+        run: |
+          set -euo pipefail
+          for manifest in crates/wasm-js/Cargo.toml crates/wasm-md/Cargo.toml; do
+            for attempt in 1 2 3; do
+              if cargo fetch --manifest-path "$manifest"; then
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                exit 1
+              fi
+              sleep $((attempt * 10))
+            done
+          done
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Summary\n- install rustfmt/clippy explicitly during Rust setup\n- pre-fetch wasm crate dependencies with bounded retries before the Turbo build\n- keep the sequential Turbo build added by ADR-29 postsubmit recovery\n\n## Context\nMain postsubmit CI for #23 caught a transient crates.io timeout while resolving js-sys during wasm build. This is a forward-only recovery hardening PR rather than a source revert.\n\n## Validation\n- ruby YAML parse for .github/workflows/ci.yml\n- actionlint with local self-hosted label ignore\n- git diff --check