### PR TITLE
docs: add project control-plane manifest

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://github.com/SylphxAI/doctrine/schemas/project-manifest.schema.json",
+  "schemaVersion": 1,
+  "project": {
+    "repo": "SylphxAI/synth",
+    "name": "Synth",
+    "lifecycle": "production",
+    "layer": "foundation",
+    "summary": "Universal AST processing and language-tooling monorepo for the @sylphx/synth package family.",
+    "goals": [
+      "Provide a fast universal AST substrate for parsing, traversal, querying, and language tooling.",
+      "Publish the @sylphx/synth package family for core AST primitives, language parsers, WASM bridges, and AST-based tooling.",
+      "Keep parser and tooling package contracts stable enough for downstream products to consume through public package exports."
+    ],
+    "nonGoals": [
+      "Own application-specific content workflows, user interfaces, billing, auth, or runtime deployment behavior.",
+      "Hardcode consumer-specific syntax behavior or product-only AST semantics into shared parser cores.",
+      "Own Sylphx Platform CI runner, preview, deployment, or production environment control planes."
+    ]
+  },
+  "boundaries": {
+    "owns": [
+      {
+        "name": "universal-ast-core",
+        "description": "Core AST node contracts, traversal helpers, and query primitives exposed by @sylphx/synth."
+      },
+      {
+        "name": "language-parser-packages",
+        "description": "Language-specific parser packages under @sylphx/synth-* for markup, programming, data, and query languages."
+      },
+      {
+        "name": "wasm-parser-bridges",
+        "description": "Rust and WebAssembly parser bridges for high-performance JavaScript, TypeScript, and Markdown parsing."
+      },
+      {
+        "name": "ast-tooling-packages",
+        "description": "Formatter, minifier, lint, metrics, typecheck, and documentation tooling built on Synth AST surfaces."
+      }
+    ],
+    "doesNotOwn": [
+      "Customer or product-specific AST behavior outside the public Synth package contracts.",
+      "Application UI, onboarding, checkout, billing, authentication, or production runtime deployment.",
+      "Sylphx Platform preview, CI runner, release infrastructure, or environment orchestration.",
+      "Downstream product data models that merely consume Synth parser outputs."
+    ],
+    "publicSurfaces": [
+      {
+        "type": "package-export",
+        "name": "@sylphx/synth package family",
+        "location": "packages/*/package.json"
+      },
+      {
+        "type": "documentation",
+        "name": "Synth documentation",
+        "location": "README.md and docs/"
+      },
+      {
+        "type": "workflow",
+        "name": "release",
+        "location": ".github/workflows/release.yml"
+      },
+      {
+        "type": "status-context",
+        "name": "ADR-29 admission",
+        "location": "risk-classification/pass and trunk-admission/pass"
+      },
+      {
+        "type": "status-context",
+        "name": "ADR-29 postsubmit recovery",
+        "location": "postsubmit-proof/pass and recovery-decision/pass"
+      }
+    ],
+    "allowedDependencies": [
+      {
+        "repo": "SylphxAI/.github",
+        "surface": "ADR-29 reusable admission action",
+        "direction": "peer-public"
+      },
+      {
+        "repo": "SylphxAI/configs",
+        "surface": "Shared Biome and TypeScript package configurations",
+        "direction": "peer-public"
+      },
+      {
+        "repo": "SylphxAI/bump",
+        "surface": "Release workflow action",
+        "direction": "peer-public"
+      },
+      {
+        "repo": "dtolnay/rust-toolchain",
+        "surface": "GitHub Action for Rust toolchain setup",
+        "direction": "external"
+      },
+      {
+        "repo": "oven-sh/setup-bun",
+        "surface": "GitHub Action for Bun toolchain setup",
+        "direction": "external"
+      }
+    ],
+    "forbiddenCouplings": [
+      "Do not add product-specific parser behavior for a single downstream repository.",
+      "Do not make Synth packages depend on application repositories or customer runtime state.",
+      "Do not bypass public package exports by having consumers import private workspace internals.",
+      "Do not move Platform preview, deployment, billing, auth, or runner policy into this repository."
+    ]
+  },
+  "documentation": {
+    "adr": {
+      "path": "docs/adr",
+      "status": "planned"
+    },
+    "specs": {
+      "path": "docs/guide",
+      "status": "present"
+    },
+    "catalog": {
+      "path": ".doctrine/project.json",
+      "status": "present"
+    },
+    "runbooks": {
+      "path": "not-applicable",
+      "status": "not-applicable"
+    },
+    "generatedReferences": {
+      "path": "docs/api",
+      "status": "present"
+    }
+  },
+  "delivery": {
+    "ciModel": "adr29-admission",
+    "requiredContexts": [
+      "risk-classification/pass",
+      "trunk-admission/pass"
+    ],
+    "deployPath": "No runtime deployment. Main-branch release workflow publishes package versions through SylphxAI/bump when package changes are releasable.",
+    "productionProof": "PRs pass ADR-29 admission; main pushes run postsubmit-proof/pass and recovery-decision/pass, and package publication is evidenced by GitHub Releases and npm package versions.",
+    "recoveryClass": "source-revertable"
+  },
+  "adoption": {
+    "status": "baseline",
+    "gaps": [
+      {
+        "id": "repo-local-adr-log",
+        "description": "Create repo-local ADRs for future material parser, package, or release-governance decisions using the central ADR numbering convention.",
+        "owner": "SylphxAI/synth",
+        "target": "Before the next material architecture or release-governance decision."
+      },
+      {
+        "id": "generated-package-catalog",
+        "description": "Generate a package capability catalog from packages/*/package.json so current package surfaces are not hand-maintained in prose.",
+        "owner": "SylphxAI/synth",
+        "target": "Before declaring full doctrine adoption."
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent Instructions - Synth
+
+This repository follows the central Sylphx doctrine:
+<https://github.com/SylphxAI/doctrine>.
+
+Before changing behavior, read:
+
+- [PROJECT.md](./PROJECT.md) for this repository's goal, boundary, public
+  surfaces, and delivery proof.
+- [.doctrine/project.json](./.doctrine/project.json) for the machine-readable
+  project manifest consumed by central audits.
+
+Local validation ladder:
+
+```bash
+bun install
+bun run lint
+bun run typecheck
+bun test
+bun run build
+```
+
+Rust/WASM parser changes also need the Rust toolchain with
+`wasm32-unknown-unknown` and should pass the relevant package build before PR.
+
+CI is wired through ADR-29 fan-in contexts:
+`risk-classification/pass` and `trunk-admission/pass`.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,52 @@
+# Synth
+
+Synth is the Sylphx universal AST processing and language-tooling monorepo. It
+owns the `@sylphx/synth` package family, language parser packages, AST traversal
+and query primitives, WASM parser bridges, and tooling packages for formatting,
+minification, linting, metrics, and documentation generation.
+
+Machine-readable project identity lives in
+[.doctrine/project.json](./.doctrine/project.json).
+
+## Lifecycle And Layer
+
+- Lifecycle: `production`
+- Layer: `foundation`
+
+## Goals
+
+- Provide a fast, shared universal AST substrate for Sylphx and external users.
+- Publish the `@sylphx/synth*` npm package family for parsers and AST tooling.
+- Keep parser/tooling package boundaries clean so downstream applications can
+  consume public package exports without repo-internal knowledge.
+
+## Non-Goals
+
+- Application-specific content workflows, UI behavior, billing, auth, or runtime
+  deployment belong outside this repository.
+- Consumer-specific syntax hacks or product-only AST behavior do not belong in
+  Synth core packages.
+- Sylphx Platform CI, preview, deploy, and runner ownership remain outside this
+  repository.
+
+## Boundary Summary
+
+Synth owns AST contracts, parser implementations, package exports, docs for the
+package family, and benchmark/tooling surfaces directly tied to Synth packages.
+Consumers use the published packages and documentation; they do not reach into
+workspace internals or couple product behavior to private parser modules.
+
+## Public Surfaces
+
+- npm packages under `@sylphx/synth*`, declared in `packages/*/package.json`.
+- Documentation under `README.md` and `docs/`.
+- Required CI contexts: `risk-classification/pass` and `trunk-admission/pass`.
+- Release workflow in `.github/workflows/release.yml` publishing through
+  `SylphxAI/bump`.
+
+## Delivery Proof
+
+Pull requests target `main` and pass ADR-29 admission contexts before merge.
+Main-branch pushes run postsubmit proof and recovery-decision wiring through
+`.github/workflows/ci.yml`. Package publication is performed by the release
+workflow after `main` changes.


### PR DESCRIPTION
## Summary
- add PROJECT.md as the repo-local orientation surface
- add .doctrine/project.json with Synth lifecycle, boundary, public surfaces, delivery proof, and adoption gaps
- add AGENTS.md as a thin runtime adapter pointing agents to doctrine and local project identity

## Validation
- python3 -m json.tool .doctrine/project.json
- git diff --check
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --local . --fail-on-drift --json
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --repo SylphxAI/synth --ref codex/project-manifest-synth --fail-on-drift --json
- python3 /Users/kyle/.doctrine/scripts/admission-conformance-audit.py --repo SylphxAI/synth --ref codex/project-manifest-synth --json

Issue: SylphxAI/doctrine#53