### PR TITLE
Use central release workflow

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -82,8 +82,8 @@
         "direction": "peer-public"
       },
       {
-        "repo": "SylphxAI/bump",
-        "surface": "Release workflow action",
+        "repo": "SylphxAI/.github",
+        "surface": "Reusable Changesets release workflow and manager-aware npm publisher.",
         "direction": "peer-public"
       },
       {
@@ -128,11 +128,8 @@
   },
   "delivery": {
     "ciModel": "adr29-admission",
-    "requiredContexts": [
-      "risk-classification/pass",
-      "trunk-admission/pass"
-    ],
-    "deployPath": "No runtime deployment. Main-branch release workflow publishes package versions through SylphxAI/bump when package changes are releasable.",
+    "requiredContexts": ["risk-classification/pass", "trunk-admission/pass"],
+    "deployPath": "No runtime deployment. Main-branch release workflow publishes package versions through the SylphxAI/.github reusable Changesets release workflow when package changes are releasable.",
     "productionProof": "PRs pass ADR-29 admission; main pushes run postsubmit-proof/pass and recovery-decision/pass, and package publication is evidenced by GitHub Releases and npm package versions.",
     "recoveryClass": "source-revertable"
   },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,41 +4,14 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release:
-    runs-on: [self-hosted, sylphx, linux, standard]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # The self-hosted runner ships bun but no node; changesets/action is a Node action.
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - run: bun install
-
-      # Version-only: pending changesets accumulate into a "Version Packages" PR.
-      # Publishing to npm is intentionally DEFERRED — synth's @sylphx/synth-*
-      # packages have never been published and a first public release is a
-      # deliberate decision. To enable publishing later, add a build step (Rust +
-      # wasm-pack + `bun run build`) and `publish: bunx @changesets/cli publish`
-      # below, plus `NPM_TOKEN`/`NODE_AUTH_TOKEN` env.
-      - uses: changesets/action@v1
-        id: changesets
-        with:
-          version: bunx @changesets/cli version
-          commit: "chore(release): version packages"
-          title: "chore(release): version packages"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      id-token: write
+    uses: SylphxAI/.github/.github/workflows/release.yml@main
+    with:
+      build: bunx turbo build --concurrency=1
+    secrets: inherit

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -42,7 +42,7 @@ workspace internals or couple product behavior to private parser modules.
 - Documentation under `README.md` and `docs/`.
 - Required CI contexts: `risk-classification/pass` and `trunk-admission/pass`.
 - Release workflow in `.github/workflows/release.yml` publishing through
-  `Changesets`.
+  the SylphxAI/.github reusable Changesets release workflow.
 
 ## Delivery Proof
 


### PR DESCRIPTION
## Summary
- replace repo-local `changesets/action` release workflow with the SylphxAI reusable release workflow
- grant the reusable workflow required publish/token permissions
- update Synth project/doctrine release docs away from retired Bump and direct publish wording

## Why
Synth is a Bun workspace with public `@sylphx/synth*` packages. The canonical release path must use the org manager-aware Changesets publisher so packed npm tarballs are audited before publication and cannot leak `workspace:` ranges.

## Validation
- `bun install`
- `bun run lint` (exit 0; existing Biome info only in `packages/synth-wasm-md/bench/turbo.bench.ts`)
- `python3 -m json.tool .doctrine/project.json >/dev/null`
- `git diff --check`