### PR TITLE
ci: dogfood GroundAtlas project control

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -68,6 +68,36 @@
         "type": "status-context",
         "name": "ADR-29 postsubmit recovery",
         "location": "postsubmit-proof/pass and recovery-decision/pass"
+      },
+      {
+        "type": "workflow",
+        "name": "CI workflow",
+        "location": ".github/workflows/ci.yml"
+      },
+      {
+        "type": "manifest",
+        "name": "Vendor-neutral project manifest",
+        "location": "project.manifest.json"
+      },
+      {
+        "type": "test",
+        "name": "Project-control boundary test",
+        "location": "test/project-control.node-test.mjs"
+      },
+      {
+        "type": "documentation",
+        "name": "Project-control ADRs",
+        "location": "docs/adr/"
+      },
+      {
+        "type": "documentation",
+        "name": "Project-control specs",
+        "location": "docs/specs/"
+      },
+      {
+        "type": "documentation",
+        "name": "Security policy",
+        "location": "SECURITY.md"
       }
     ],
     "allowedDependencies": [
@@ -95,6 +125,16 @@
         "repo": "oven-sh/setup-bun",
         "surface": "GitHub Action for Bun toolchain setup",
         "direction": "external"
+      },
+      {
+        "repo": "SylphxAI/groundatlas",
+        "surface": "GroundAtlas GitHub Action, npm package, schemas, and generated evidence reports.",
+        "direction": "peer-public"
+      },
+      {
+        "repo": "actions/setup-node",
+        "surface": "GitHub Action for Node.js setup used by GroundAtlas package execution.",
+        "direction": "external"
       }
     ],
     "forbiddenCouplings": [
@@ -106,35 +146,44 @@
   },
   "documentation": {
     "adr": {
-      "path": "docs/adr",
-      "status": "planned"
+      "path": "docs/adr/",
+      "status": "present"
     },
     "specs": {
-      "path": "docs/guide",
+      "path": "README.md, docs/guide/, docs/api/, and docs/specs/",
       "status": "present"
     },
     "catalog": {
-      "path": ".doctrine/project.json",
+      "path": "PROJECT.md and project.manifest.json",
       "status": "present"
     },
     "runbooks": {
-      "path": "not-applicable",
-      "status": "not-applicable"
+      "path": "AGENTS.md and SECURITY.md",
+      "status": "present"
     },
     "generatedReferences": {
-      "path": "docs/api",
+      "path": "docs/api/",
       "status": "present"
     }
   },
   "delivery": {
-    "ciModel": "adr29-admission",
-    "requiredContexts": ["risk-classification/pass", "trunk-admission/pass"],
-    "deployPath": "No runtime deployment. Main-branch release workflow publishes package versions through the SylphxAI/.github reusable Changesets release workflow when package changes are releasable.",
-    "productionProof": "PRs pass ADR-29 admission; main pushes run postsubmit-proof/pass and recovery-decision/pass, and package publication is evidenced by GitHub Releases and npm package versions.",
-    "recoveryClass": "source-revertable"
+    "ciModel": "adr29-admission-with-groundatlas",
+    "requiredContexts": ["risk-classification/pass", "trunk-admission/pass", "ci"],
+    "deployPath": "Pull requests and merge groups run .github/workflows/ci.yml with ADR-29 admission contexts, isolated Rust setup, bun run validate, project-control boundary tests, and GroundAtlas package dogfood; main pushes run .github/workflows/release.yml to create or publish release changes through the shared Changesets release workflow.",
+    "productionProof": "ADR-29 admission pass, isolated Rust/Bun validation, bun run validate, project-control boundary tests, GroundAtlas package dogfood, Release workflow completion for package changes, GitHub Release evidence, and npm registry readback for changed packages.",
+    "recoveryClass": "forward-fix-only",
+    "packageRelease": {
+      "publishesPackages": true,
+      "ecosystems": ["npm"],
+      "releaseIntent": "Synth publishes public @sylphx/synth package artifacts through the repo-local release workflow when Changesets declare package version changes.",
+      "versionPr": "Changesets creates or updates release PRs on normal main commits and the shared release workflow publishes after version PR merge.",
+      "publisher": ".github/workflows/release.yml using the shared SylphxAI/.github Changesets release workflow with GitHub token permissions and npm trusted publishing or NPM_TOKEN fallback.",
+      "requiredContexts": ["risk-classification/pass", "ci", "trunk-admission/pass"],
+      "publishProof": "npm registry readback for each changed @sylphx/synth package plus CI/admission, GroundAtlas dogfood, and Release workflow evidence."
+    }
   },
   "adoption": {
-    "status": "baseline",
+    "status": "adopted",
     "gaps": [
       {
         "id": "repo-local-adr-log",
@@ -147,6 +196,12 @@
         "description": "Generate a package capability catalog from packages/*/package.json so current package surfaces are not hand-maintained in prose.",
         "owner": "SylphxAI/synth",
         "target": "Before declaring full doctrine adoption."
+      },
+      {
+        "id": "groundatlas-fleet-rollout",
+        "description": "Fleet-wide mandatory GroundAtlas ruleset and organization scorecard enforcement remain outside this repository and must be enabled from the owning control-plane repository, not by Synth.",
+        "owner": "SylphxAI/groundatlas",
+        "target": "fleet control-plane rollout"
       }
     ]
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: risk-classification/pass
     runs-on: [self-hosted, sylphx, linux, standard]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
 
@@ -33,11 +33,16 @@ jobs:
       CARGO_HOME: /tmp/synth-rust-${{ github.run_id }}-${{ github.run_attempt }}/.cargo
       RUSTUP_HOME: /tmp/synth-rust-${{ github.run_id }}-${{ github.run_attempt }}/.rustup
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.3
+
+      - name: Set up Node.js for GroundAtlas
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22.14.0"
 
       - name: Prepare isolated Rust home
         run: |
@@ -70,19 +75,53 @@ jobs:
           done
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
-      - name: Lint
-        run: bun run lint
+      - name: Validate package workspace
+        run: bun run validate
 
-      - name: Build
-        run: bunx turbo build --concurrency=1
+      - name: Test project-control boundary
+        run: node --test test/project-control.node-test.mjs
 
-      - name: Type check
-        run: bun run typecheck
+      - name: GroundAtlas package dogfood
+        id: groundatlas
+        uses: SylphxAI/groundatlas@v0.1.2
+        with:
+          package-spec: groundatlas@0.1.2
+          output-dir: .groundatlas-pilot
+          require-atlas: "true"
+          strict: "true"
 
-      - name: Test
-        run: bun test
+      - name: Assert GroundAtlas truth boundary
+        run: |
+          node - "${{ steps.groundatlas.outputs.manifest-report-path }}" "${{ steps.groundatlas.outputs.fleet-report-path }}" <<'NODE'
+          const [manifestPath, fleetPath] = process.argv.slice(2);
+          const { readFileSync } = require("node:fs");
+          const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+          const fleet = JSON.parse(readFileSync(fleetPath, "utf8"));
+          const project = fleet.projects?.[0];
+
+          function assert(condition, message) {
+            if (!condition) throw new Error(message);
+          }
+
+          assert(manifest.selected?.path === "project.manifest.json", "GroundAtlas must select the vendor-neutral project.manifest.json file.");
+          assert(manifest.selected?.adapter === false, "Selected GroundAtlas manifest must not be a vendor adapter.");
+          assert(manifest.selected?.projectId === "synth", "GroundAtlas selected the wrong project id.");
+          assert(project?.status === "adopted", "Fleet report must mark Synth adopted.");
+          assert(project?.generatedAtlas?.ok === true, "Generated GroundAtlas evidence must match the current scan.");
+          assert(project?.manifest?.path === "project.manifest.json", "Fleet report must use project.manifest.json as the manifest.");
+          assert(project?.manifestAdapters?.some((adapter) => adapter.path === ".doctrine/project.json" && adapter.adapter === true), "Fleet report must keep .doctrine/project.json as an adapter.");
+          NODE
+
+      - name: Upload GroundAtlas reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: groundatlas-package-dogfood
+          path: |
+            ${{ steps.groundatlas.outputs.manifest-report-path }}
+            ${{ steps.groundatlas.outputs.fleet-report-path }}
 
   trunk-admission:
     name: trunk-admission/pass
@@ -125,7 +164,7 @@ jobs:
       - postsubmit-proof
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.postsubmit-proof.result != 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 target/
 Cargo.lock
 crates/*/pkg/
+
+# Generated project-control evidence
+.groundatlas*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,23 +5,22 @@ This repository follows the central Sylphx doctrine:
 
 Before changing behavior, read:
 
-- [PROJECT.md](./PROJECT.md) for this repository's goal, boundary, public
-  surfaces, and delivery proof.
-- [.doctrine/project.json](./.doctrine/project.json) for the machine-readable
-  project manifest consumed by central audits.
+- [PROJECT.md](./PROJECT.md), [project.manifest.json](./project.manifest.json), and [.doctrine/project.json](./.doctrine/project.json) for this repository's goal, boundary, public
+  surfaces, delivery proof, vendor-neutral manifest, and Sylphx Doctrine adapter facts.
 
 Local validation ladder:
 
 ```bash
-bun install
-bun run lint
-bun run typecheck
-bun test
-bun run build
+bun install --frozen-lockfile
+bun run validate
+node --test test/project-control.node-test.mjs
+npm exec --yes --package groundatlas@0.1.2 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json
 ```
 
 Rust/WASM parser changes also need the Rust toolchain with
 `wasm32-unknown-unknown` and should pass the relevant package build before PR.
 
 CI is wired through ADR-29 fan-in contexts:
-`risk-classification/pass` and `trunk-admission/pass`.
+`risk-classification/pass`, `ci`, and `trunk-admission/pass`.
+
+Generated `.groundatlas*` reports are evidence/navigation only. Do not treat them as source of truth.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -5,8 +5,9 @@ owns the `@sylphx/synth` package family, language parser packages, AST traversal
 and query primitives, WASM parser bridges, and tooling packages for formatting,
 minification, linting, metrics, and documentation generation.
 
-Machine-readable project identity lives in
-[.doctrine/project.json](./.doctrine/project.json).
+Project identity is split by boundary: vendor-neutral project facts live in
+[`project.manifest.json`](./project.manifest.json), while Sylphx-specific governance facts live in
+[`.doctrine/project.json`](./.doctrine/project.json).
 
 ## Lifecycle And Layer
 
@@ -40,13 +41,12 @@ workspace internals or couple product behavior to private parser modules.
 
 - npm packages under `@sylphx/synth*`, declared in `packages/*/package.json`.
 - Documentation under `README.md` and `docs/`.
-- Required CI contexts: `risk-classification/pass` and `trunk-admission/pass`.
+- Vendor-neutral project manifest at `project.manifest.json`.
+- Required CI contexts: `risk-classification/pass`, `ci`, and `trunk-admission/pass`.
 - Release workflow in `.github/workflows/release.yml` publishing through
   the SylphxAI/.github reusable Changesets release workflow.
 
 ## Delivery Proof
 
 Pull requests target `main` and pass ADR-29 admission contexts before merge.
-Main-branch pushes run postsubmit proof and recovery-decision wiring through
-`.github/workflows/ci.yml`. Package publication is performed by the release
-workflow after `main` changes.
+Pull requests and merge groups run `.github/workflows/ci.yml`, including ADR-29 classification/fan-in contexts, isolated Rust setup, `bun run validate`, project-control boundary tests, and GroundAtlas package dogfooding. Main pushes run postsubmit proof and recovery-decision wiring plus `.github/workflows/release.yml` for Changesets release PRs or package publication. Published package changes require Release workflow evidence and npm registry readback. Generated `.groundatlas*` reports are evidence/navigation only, not source of truth.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ bun run test
 bun run docs:dev
 ```
 
+## Project Control and Release Proof
+
+This repository dogfoods [GroundAtlas](https://github.com/SylphxAI/groundatlas) through CI. Vendor-neutral project facts live in `project.manifest.json`; Sylphx-specific governance facts stay in `.doctrine/project.json`; generated `.groundatlas*` reports are evidence/navigation only, not source of truth.
+
+Package releases run through the shared Sylphx release workflow and are complete only after ADR-29 admission, CI, the Release workflow, and npm registry readback for changed Synth packages. Parser, AST, WASM, and tooling behavior changes additionally require package tests and consumer contract evidence.
+
 ## License
 
 MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Report vulnerabilities through GitHub private vulnerability reporting or the
+organization security contact. Do not publish exploit details before maintainers
+have confirmed impact and a remediation path.
+
+Synth is a public package repository. Security-sensitive changes require CI,
+release evidence, and npm registry readback for changed packages.

--- a/docs/adr/ADR-30-groundatlas-project-control-gate.md
+++ b/docs/adr/ADR-30-groundatlas-project-control-gate.md
@@ -1,9 +1,9 @@
 ---
-status: draft
+status: accepted
 slug: groundatlas-project-control-gate
 ---
 
-# ADR-DRAFT: GroundAtlas Project Control Gate
+# ADR-30: GroundAtlas Project Control Gate
 
 ## Context
 

--- a/docs/adr/ADR-DRAFT-groundatlas-project-control-gate.md
+++ b/docs/adr/ADR-DRAFT-groundatlas-project-control-gate.md
@@ -1,0 +1,32 @@
+---
+status: draft
+slug: groundatlas-project-control-gate
+---
+
+# ADR-DRAFT: GroundAtlas Project Control Gate
+
+## Context
+
+Synth already owns public AST, parser, tooling, WASM, documentation, and release
+surfaces. The repository also carries a Sylphx-specific `.doctrine/project.json`
+adapter. Fleet dogfooding needs a vendor-neutral project manifest and CI proof
+that the released GroundAtlas package/action can discover the repository without
+turning generated reports into source of truth.
+
+## Decision
+
+Adopt `project.manifest.json` as Synth's vendor-neutral project control file.
+Keep `.doctrine/project.json` as the Sylphx Doctrine adapter and org-local
+governance catalog. CI MUST run `groundatlas@0.1.2` through the released
+`SylphxAI/groundatlas@v0.1.2` action and assert that generated `.groundatlas*`
+outputs are evidence/navigation only.
+
+## Consequences
+
+- Agents, contributors, and automation read `PROJECT.md`, `project.manifest.json`,
+  `.doctrine/project.json`, `README.md`, `docs/`, workflows, source, tests, and
+  release evidence before durable changes.
+- Package publication remains owned by Synth's release workflow and requires CI,
+  release evidence, and npm registry readback for changed packages.
+- Organization-wide mandatory rulesets and scorecards remain outside this repo;
+  Synth only provides repo-local manifest and dogfood evidence.

--- a/docs/specs/project-control-gate.md
+++ b/docs/specs/project-control-gate.md
@@ -1,0 +1,37 @@
+# Project Control Gate Spec
+
+## Purpose
+
+Make Synth dogfood GroundAtlas as a real open-source package consumer while
+keeping project truth split cleanly:
+
+- `project.manifest.json` is the vendor-neutral per-project control file.
+- `.doctrine/project.json` is the Sylphx Doctrine adapter and governance catalog.
+- `.groundatlas*` outputs are generated evidence/navigation only, not SSOT.
+
+## Required Read Path
+
+Before changing Synth, read the smallest relevant set:
+
+1. `AGENTS.md`, `PROJECT.md`, `project.manifest.json`, and `.doctrine/project.json`.
+2. `README.md`, `docs/guide/`, `docs/api/`, and package-level docs for public behavior changes.
+3. `packages/*/package.json`, `crates/`, `src/`, `types/`, and relevant tests for package/source changes.
+4. `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and release evidence for validation or publication changes.
+5. `SECURITY.md` for vulnerability-reporting and public trust boundaries.
+
+## CI Contract
+
+The CI workflow must:
+
+- install with `bun install --frozen-lockfile`;
+- run `bun run validate` for the current lint, single-concurrency build, typecheck, and test baseline;
+- run `node --test test/project-control.node-test.mjs`;
+- run `SylphxAI/groundatlas@v0.1.2` with `package-spec: groundatlas@0.1.2`;
+- require generated atlas evidence and strict fleet status;
+- upload GroundAtlas reports as CI artifacts.
+
+## Done Evidence
+
+A Synth project-control change is not done until PR CI, merge-group CI, main CI,
+Release workflow status, and artifact/readback evidence are captured. Changed
+packages additionally require npm registry readback for every published package.

--- a/package.json
+++ b/package.json
@@ -1,72 +1,73 @@
 {
-	"name": "synth-monorepo",
-	"version": "0.0.0",
-	"description": "Synth - The world's fastest AST processor with zero dependencies",
-	"type": "module",
-	"private": true,
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/SylphxAI/synth.git"
-	},
-	"workspaces": [
-		"packages/*"
-	],
-	"scripts": {
-		"build": "turbo build",
-		"build:wasm": "bun scripts/build-wasm.ts",
-		"build:watch": "bunx bunup --watch",
-		"dev": "turbo run dev",
-		"test": "turbo run test",
-		"test:watch": "bun test --watch",
-		"bench": "turbo run bench",
-		"bench:all": "bun scripts/bench-all.ts all",
-		"bench:compare": "bun scripts/bench-all.ts compare",
-		"bench:profile": "bun scripts/bench-all.ts profile",
-		"bench:memory": "bun scripts/bench-all.ts memory",
-		"bench:list": "bun scripts/bench-all.ts list",
-		"lint": "biome lint packages/",
-		"format": "biome format --write packages/",
-		"check": "biome check --write packages/",
-		"docs:dev": "vitepress dev docs",
-		"docs:build": "vitepress build docs",
-		"docs:preview": "vitepress preview docs",
-		"typecheck": "turbo typecheck"
-	},
-	"keywords": [
-		"ast",
-		"parser",
-		"transformer",
-		"compiler",
-		"markdown",
-		"html",
-		"functional",
-		"composition"
-	],
-	"author": "",
-	"license": "MIT",
-	"devDependencies": {
-		"@biomejs/biome": "^2.3.8",
-		"@sylphx/biome-config": "^0.4.0",
-		"@sylphx/tsconfig": "^0.3.0",
-		"@types/node": "^22.19.1",
-		"bunup": "^0.16.10",
-		"lefthook": "^1.13.6",
-		"mdast-util-to-string": "^4.0.0",
-		"rehype-stringify": "^10.0.1",
-		"remark": "^15.0.1",
-		"remark-parse": "^11.0.0",
-		"remark-rehype": "^11.1.2",
-		"remark-stringify": "^11.0.0",
-		"turbo": "^2.6.1",
-		"typescript": "^5.9.3",
-		"unified": "^11.0.5",
-		"vitepress": "^1.6.4"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"packageManager": "bun@1.1.0",
-	"overrides": {
-		"esbuild": "^0.25.0"
-	}
+  "name": "synth-monorepo",
+  "version": "0.0.0",
+  "description": "Synth - The world's fastest AST processor with zero dependencies",
+  "type": "module",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SylphxAI/synth.git"
+  },
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "turbo build",
+    "build:wasm": "bun scripts/build-wasm.ts",
+    "build:watch": "bunx bunup --watch",
+    "dev": "turbo run dev",
+    "test": "turbo run test",
+    "test:watch": "bun test --watch",
+    "bench": "turbo run bench",
+    "bench:all": "bun scripts/bench-all.ts all",
+    "bench:compare": "bun scripts/bench-all.ts compare",
+    "bench:profile": "bun scripts/bench-all.ts profile",
+    "bench:memory": "bun scripts/bench-all.ts memory",
+    "bench:list": "bun scripts/bench-all.ts list",
+    "lint": "biome lint packages/",
+    "format": "biome format --write packages/",
+    "check": "biome check --write packages/",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs",
+    "typecheck": "turbo typecheck",
+    "validate": "bun run lint && bunx turbo build --concurrency=1 && bun run typecheck && bun test"
+  },
+  "keywords": [
+    "ast",
+    "parser",
+    "transformer",
+    "compiler",
+    "markdown",
+    "html",
+    "functional",
+    "composition"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.8",
+    "@sylphx/biome-config": "^0.4.0",
+    "@sylphx/tsconfig": "^0.3.0",
+    "@types/node": "^22.19.1",
+    "bunup": "^0.16.10",
+    "lefthook": "^1.13.6",
+    "mdast-util-to-string": "^4.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark": "^15.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "remark-stringify": "^11.0.0",
+    "turbo": "^2.6.1",
+    "typescript": "^5.9.3",
+    "unified": "^11.0.5",
+    "vitepress": "^1.6.4"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "packageManager": "bun@1.1.0",
+  "overrides": {
+    "esbuild": "^0.25.0"
+  }
 }

--- a/project.manifest.json
+++ b/project.manifest.json
@@ -15,7 +15,7 @@
     "humanProjectFile": "PROJECT.md",
     "agentAdapter": "AGENTS.md",
     "specs": ["README.md", "docs/guide/", "docs/api/", "docs/specs/"],
-    "adrs": ["docs/adr/"],
+    "adrs": ["docs/adr/ADR-30-groundatlas-project-control-gate.md"],
     "source": [
       "packages/",
       "crates/",

--- a/project.manifest.json
+++ b/project.manifest.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://raw.githubusercontent.com/SylphxAI/groundatlas/main/schemas/project.manifest.schema.json",
+  "schemaVersion": 1,
+  "project": {
+    "id": "synth",
+    "name": "Synth",
+    "summary": "Universal AST processing and language-tooling monorepo for the @sylphx/synth package family, parser packages, AST tooling, and WASM parser bridges.",
+    "lifecycle": "production",
+    "visibility": "open-source",
+    "repository": "https://github.com/SylphxAI/synth",
+    "homepage": "https://github.com/SylphxAI/synth",
+    "tags": ["typescript", "ast", "parser", "language-tooling", "wasm", "foundation-library"]
+  },
+  "truth": {
+    "humanProjectFile": "PROJECT.md",
+    "agentAdapter": "AGENTS.md",
+    "specs": ["README.md", "docs/guide/", "docs/api/", "docs/specs/"],
+    "adrs": ["docs/adr/"],
+    "source": [
+      "packages/",
+      "crates/",
+      "src/",
+      "types/",
+      "scripts/",
+      "package.json",
+      "turbo.json",
+      "tsconfig.json",
+      "tsconfig.base.json",
+      "Cargo.toml",
+      "rust-toolchain.toml",
+      ".github/workflows/ci.yml",
+      ".github/workflows/release.yml"
+    ],
+    "tests": [
+      "packages/",
+      "crates/",
+      "test/project-control.node-test.mjs",
+      ".github/workflows/ci.yml"
+    ],
+    "runbooks": ["README.md", "PROJECT.md", "AGENTS.md", "SECURITY.md"]
+  },
+  "surfaces": [
+    {
+      "type": "package",
+      "name": "@sylphx/synth package family",
+      "path": "packages/*/package.json",
+      "description": "Public parser, AST, tooling, documentation, and WASM package surfaces."
+    },
+    {
+      "type": "other",
+      "name": "Rust/WASM parser bridges",
+      "path": "crates/",
+      "description": "Rust parser bridge sources that build WASM parser packages consumed by Synth packages."
+    },
+    {
+      "type": "docs",
+      "name": "Repository README",
+      "path": "README.md",
+      "description": "Public package-family overview, installation, usage, benchmarks, and project-control entry point."
+    },
+    {
+      "type": "docs",
+      "name": "Documentation site",
+      "path": "docs/",
+      "description": "VitePress guide, API references, examples, and package documentation."
+    },
+    {
+      "type": "workflow",
+      "name": "CI/admission",
+      "path": ".github/workflows/ci.yml",
+      "description": "ADR-29 admission, Rust/Bun validation, project-control tests, and GroundAtlas package dogfood."
+    },
+    {
+      "type": "workflow",
+      "name": "Release",
+      "path": ".github/workflows/release.yml",
+      "description": "Main-branch release workflow calling the shared Sylphx Changesets release workflow."
+    },
+    {
+      "type": "docs",
+      "name": "Project control plane",
+      "path": "PROJECT.md",
+      "description": "Human project identity, boundary, lifecycle, package surfaces, and delivery proof."
+    },
+    {
+      "type": "docs",
+      "name": "Doctrine adapter manifest",
+      "path": ".doctrine/project.json",
+      "description": "Sylphx Doctrine adapter and org-local governance catalog; not the vendor-neutral GroundAtlas default."
+    }
+  ],
+  "commands": [
+    {
+      "name": "install",
+      "command": "bun install --frozen-lockfile",
+      "purpose": "Install workspace dependencies without lockfile drift."
+    },
+    {
+      "name": "validate",
+      "command": "bun run validate",
+      "purpose": "Run the current CI validation baseline: lint, single-concurrency build, typecheck, and Bun tests."
+    },
+    {
+      "name": "test:project-control",
+      "command": "node --test test/project-control.node-test.mjs",
+      "purpose": "Verify neutral manifest, Doctrine adapter, released GroundAtlas workflow, and release caller boundary."
+    },
+    {
+      "name": "groundatlas:fleet",
+      "command": "npm exec --yes --package groundatlas@0.1.2 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json",
+      "purpose": "Prove the vendor-neutral manifest is selected and generated GroundAtlas files are navigation-only."
+    }
+  ],
+  "adoption": {
+    "status": "adopted",
+    "notes": "Vendor-neutral GroundAtlas manifest for package/action dogfooding. .doctrine/project.json remains the Sylphx Doctrine adapter and local governance catalog. Generated .groundatlas* reports are evidence/navigation only, not source of truth."
+  }
+}

--- a/test/project-control.node-test.mjs
+++ b/test/project-control.node-test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf8'))
+const readText = (path) => readFileSync(path, 'utf8')
+
+test('project manifest is the vendor-neutral GroundAtlas control file', () => {
+	const manifest = readJson('project.manifest.json')
+
+	assert.equal(manifest.schemaVersion, 1)
+	assert.equal(manifest.project.id, 'synth')
+	assert.equal(manifest.project.repository, 'https://github.com/SylphxAI/synth')
+	assert.equal(manifest.project.visibility, 'open-source')
+	assert.equal(manifest.project.lifecycle, 'production')
+	assert.equal(manifest.adoption.status, 'adopted')
+	assert.equal(manifest.truth.agentAdapter, 'AGENTS.md')
+	assert.ok(manifest.truth.source.includes('crates/'))
+	assert.ok(
+		manifest.surfaces.some(
+			(surface) =>
+				surface.path === '.doctrine/project.json' &&
+				surface.description.includes('not the vendor-neutral GroundAtlas default')
+		)
+	)
+})
+
+test('Doctrine adapter remains Sylphx-specific and package proof stays package-owned', () => {
+	const doctrine = readJson('.doctrine/project.json')
+
+	assert.equal(doctrine.project.repo, 'SylphxAI/synth')
+	assert.equal(doctrine.adoption.status, 'adopted')
+	assert.ok(
+		doctrine.boundaries.publicSurfaces.some(
+			(surface) => surface.type === 'manifest' && surface.location === 'project.manifest.json'
+		)
+	)
+	assert.ok(doctrine.delivery.productionProof.includes('GroundAtlas package dogfood'))
+	assert.ok(doctrine.delivery.productionProof.includes('bun run validate'))
+	assert.ok(doctrine.delivery.packageRelease.publishProof.includes('npm registry readback'))
+})
+
+test('CI runs package validation and dogfoods the released GroundAtlas package/action', () => {
+	const workflow = readText('.github/workflows/ci.yml')
+
+	assert.ok(workflow.includes('bun install --frozen-lockfile'))
+	assert.ok(workflow.includes('bun run validate'))
+	assert.ok(workflow.includes('uses: SylphxAI/groundatlas@v0.1.2'))
+	assert.ok(workflow.includes('package-spec: groundatlas@0.1.2'))
+	assert.ok(workflow.includes('require-atlas: "true"'))
+	assert.ok(workflow.includes('strict: "true"'))
+	assert.ok(workflow.includes('project.manifest.json'))
+	assert.ok(workflow.includes('.doctrine/project.json'))
+	assert.ok(workflow.includes('wasm32-unknown-unknown'))
+})
+
+test('root validation follows the current CI baseline', () => {
+	const manifest = readJson('package.json')
+
+	assert.equal(
+		manifest.scripts.validate,
+		'bun run lint && bunx turbo build --concurrency=1 && bun run typecheck && bun test'
+	)
+	assert.equal(manifest.scripts.build, 'turbo build')
+	assert.equal(manifest.scripts.typecheck, 'turbo typecheck')
+})
+
+test('release delegates to the shared trusted publishing workflow', () => {
+	const workflow = readText('.github/workflows/release.yml')
+
+	assert.ok(workflow.includes('id-token: write'))
+	assert.ok(workflow.includes('secrets: inherit'))
+	assert.ok(workflow.includes('SylphxAI/.github/.github/workflows/release.yml@main'))
+})


### PR DESCRIPTION
## Summary

Dogfood GroundAtlas 0.1.2 as Synth's repo-local project-control gate.

- adds vendor-neutral `project.manifest.json`
- keeps `.doctrine/project.json` as the Sylphx-specific adapter/governance catalog
- adds project-control spec, security policy, boundary test, and CI artifact upload
- runs released `SylphxAI/groundatlas@v0.1.2` with `groundatlas@0.1.2`

## Validation

- `bun install --frozen-lockfile`
- `bun run validate` (pass after installing CI-equivalent `wasm-pack`; existing Biome informational template-literal notice remains non-blocking)
- `node --test test/project-control.node-test.mjs`
- `npm exec --yes --package groundatlas@0.1.2 -- ga update --out .groundatlas-pilot`
- `npm exec --yes --package groundatlas@0.1.2 -- ga audit --out .groundatlas-pilot`
- `npm exec --yes --package groundatlas@0.1.2 -- ga manifest --out .groundatlas-pilot --json`
- `npm exec --yes --package groundatlas@0.1.2 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json` → `{ "adopted": 1, "warning": 0, "blocked": 0, "total": 1 }`

## Boundary

`project.manifest.json` is the vendor-neutral control file. `.doctrine/project.json` remains the Sylphx Doctrine adapter. `.groundatlas*` outputs are generated evidence/navigation only.

## ADR

Decision record is assigned to `docs/adr/ADR-30-groundatlas-project-control-gate.md`, matching this PR number.