### PR TITLE
docs: define Synth MCP family AST foundation

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -10,11 +10,13 @@
     "goals": [
       "Provide a fast universal AST substrate for parsing, traversal, querying, and language tooling.",
       "Publish the @sylphx/synth package family for core AST primitives, language parsers, WASM bridges, and AST-based tooling.",
-      "Keep parser and tooling package contracts stable enough for downstream products to consume through public package exports."
+      "Keep parser and tooling package contracts stable enough for downstream products to consume through public package exports.",
+      "Serve the Rust-native MCP family as a product-neutral AST foundation through public packages, generated contracts, fixtures, benchmarks, and Rust/WASM bridge outputs."
     ],
     "nonGoals": [
       "Own application-specific content workflows, user interfaces, billing, auth, or runtime deployment behavior.",
       "Hardcode consumer-specific syntax behavior or product-only AST semantics into shared parser cores.",
+      "Own MCP server runtime, transport, tool schemas, install packaging, or product roadmaps for downstream MCP repositories.",
       "Own Sylphx Platform CI runner, preview, deployment, or production environment control planes."
     ]
   },
@@ -96,6 +98,11 @@
       },
       {
         "type": "documentation",
+        "name": "MCP family AST foundation roadmap",
+        "location": "docs/roadmap/mcp-family-ast-foundation.md"
+      },
+      {
+        "type": "documentation",
         "name": "Security policy",
         "location": "SECURITY.md"
       }
@@ -141,6 +148,7 @@
       "Do not add product-specific parser behavior for a single downstream repository.",
       "Do not make Synth packages depend on application repositories or customer runtime state.",
       "Do not bypass public package exports by having consumers import private workspace internals.",
+      "Do not add a TypeScript MCP adapter to Synth as the runtime strategy for downstream products.",
       "Do not move Platform preview, deployment, billing, auth, or runner policy into this repository."
     ]
   },
@@ -196,6 +204,12 @@
         "description": "Generate a package capability catalog from packages/*/package.json so current package surfaces are not hand-maintained in prose.",
         "owner": "SylphxAI/synth",
         "target": "Before declaring full doctrine adoption."
+      },
+      {
+        "id": "mcp-family-contract-fixtures",
+        "description": "Define generated AST contract fixtures and Rust/WASM consumption criteria before downstream Rust-native MCP products rely on Synth as their structural source.",
+        "owner": "SylphxAI/synth",
+        "target": "MCP family AST foundation implementation slice."
       },
       {
         "id": "groundatlas-fleet-rollout",

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -20,6 +20,9 @@ Project identity is split by boundary: vendor-neutral project facts live in
 - Publish the `@sylphx/synth*` npm package family for parsers and AST tooling.
 - Keep parser/tooling package boundaries clean so downstream applications can
   consume public package exports without repo-internal knowledge.
+- Serve the Rust-native MCP family as a product-neutral AST foundation through
+  public packages, generated contracts, fixtures, benchmarks, and Rust/WASM
+  bridge outputs.
 
 ## Non-Goals
 
@@ -27,6 +30,8 @@ Project identity is split by boundary: vendor-neutral project facts live in
   deployment belong outside this repository.
 - Consumer-specific syntax hacks or product-only AST behavior do not belong in
   Synth core packages.
+- MCP server runtime, transport, tool schemas, install packaging, and product
+  roadmaps belong in the owning MCP repositories, not in Synth.
 - Sylphx Platform CI, preview, deploy, and runner ownership remain outside this
   repository.
 
@@ -41,6 +46,8 @@ workspace internals or couple product behavior to private parser modules.
 
 - npm packages under `@sylphx/synth*`, declared in `packages/*/package.json`.
 - Documentation under `README.md` and `docs/`.
+- MCP family AST foundation roadmap:
+  [`docs/roadmap/mcp-family-ast-foundation.md`](./docs/roadmap/mcp-family-ast-foundation.md)
 - Vendor-neutral project manifest at `project.manifest.json`.
 - Required CI contexts: `risk-classification/pass`, `ci`, and `trunk-admission/pass`.
 - Release workflow in `.github/workflows/release.yml` publishing through

--- a/docs/adr/ADR-35-mcp-family-ast-foundation.md
+++ b/docs/adr/ADR-35-mcp-family-ast-foundation.md
@@ -1,9 +1,9 @@
 ---
-status: draft
+status: proposed
 slug: mcp-family-ast-foundation
 ---
 
-# ADR-DRAFT: MCP Family AST Foundation
+# ADR-35: MCP Family AST Foundation
 
 ## Context
 

--- a/docs/adr/ADR-DRAFT-mcp-family-ast-foundation.md
+++ b/docs/adr/ADR-DRAFT-mcp-family-ast-foundation.md
@@ -1,0 +1,81 @@
+---
+status: draft
+slug: mcp-family-ast-foundation
+---
+
+# ADR-DRAFT: MCP Family AST Foundation
+
+## Context
+
+Synth owns the public AST substrate for Sylphx parser, traversal, query,
+tooling, and WASM parser surfaces. The MCP family now needs a consistent way for
+repository architecture, code retrieval, reader evidence, filesystem, and
+consultation tools to reason about source structure without each product
+inventing its own parser contracts.
+
+The MCP server runtime target for product repositories is Rust using the
+official Rust MCP SDK. Synth is not an MCP server repository and should not add a
+TypeScript MCP adapter to serve downstream products. Its leverage is the
+foundation layer: stable AST contracts, parser fixtures, query semantics,
+language coverage, benchmarks, and generated package metadata that Rust-native
+MCP products can consume through public, versioned surfaces.
+
+## Decision
+
+Synth will serve the MCP family as the AST foundation, not as an MCP runtime.
+
+Synth owns:
+
+- language-neutral AST node contracts and source-span invariants;
+- parser fixtures and conformance cases for language families;
+- query and traversal semantics that downstream products can validate against;
+- benchmark suites for parser latency, memory, incremental parsing, and package
+  size;
+- generated package capability metadata from the public package manifests;
+- Rust/WASM parser bridge boundaries where they are part of Synth package
+  delivery.
+
+Product repositories own their MCP server behavior, tool schemas, security
+policy, transport, install packaging, runtime telemetry, and customer-facing
+roadmaps. Rust-native MCP servers may use Synth packages, generated schemas,
+fixtures, or Rust/WASM bridge outputs, but must not import Synth workspace
+internals or make Synth aware of product-specific workflows.
+
+TypeScript remains acceptable inside Synth for existing package implementation
+and public JavaScript package delivery. It is not a target MCP adapter layer for
+the Sylphx MCP family.
+
+## Consequences
+
+- Architecture and code-intelligence products get one shared AST vocabulary
+  without coupling Synth to their runtime decisions.
+- Rust-native MCP products can validate their indexing, chunking, evidence, and
+  navigation behavior against Synth fixtures instead of duplicating ad hoc
+  parser expectations.
+- Synth can improve language coverage and performance once for the portfolio.
+- Product-specific semantics stay out of Synth core packages.
+- Future shared primitives should be generated contracts, fixtures, crates, or
+  package exports, not cross-repo private imports.
+
+## Migration
+
+1. Add a roadmap that defines Synth's MCP-family foundation role.
+2. Generate a package capability catalog from `packages/*/package.json` before
+   relying on a hand-written package list as current truth.
+3. Define AST fixture groups for repository architecture and code retrieval
+   consumers.
+4. Add Rust/WASM bridge acceptance criteria for downstream Rust MCP products:
+   deterministic parse output, stable spans, bounded memory, and benchmark
+   thresholds.
+5. Have product repositories consume the public contract through their own ADRs,
+   tests, and release gates.
+
+## Verification
+
+- JSON project manifests parse.
+- Repo-local documentation points to this decision and keeps current-state facts
+  in project manifests.
+- No MCP server package or TypeScript MCP adapter is added to Synth by this
+  decision.
+- Future implementation slices add generated contract checks or fixture tests
+  before claiming product consumption is complete.

--- a/docs/roadmap/mcp-family-ast-foundation.md
+++ b/docs/roadmap/mcp-family-ast-foundation.md
@@ -1,0 +1,110 @@
+# MCP Family AST Foundation Roadmap
+
+Decision record: `docs/adr/ADR-DRAFT-mcp-family-ast-foundation.md`
+
+Synth is the AST substrate for the Sylphx MCP family. It should make source
+structure fast, stable, and portable for Rust-native MCP products without
+becoming an MCP server itself.
+
+## Role In The Family
+
+Synth gives the portfolio a shared structural language:
+
+- repository architecture tools use AST spans, symbols, imports, and hierarchy
+  to build evidence graphs;
+- code retrieval tools use language-aware chunks, symbol neighborhoods, and
+  incremental re-indexing signals;
+- reader tools can use structured Markdown, HTML, JSON, YAML, and document-side
+  code blocks as citeable evidence;
+- filesystem tools can validate safe transformations against parser spans;
+- consultation tools can cite structural facts instead of prose-only summaries.
+
+The product MCP servers own runtime behavior. Synth owns the reusable parser and
+AST contracts they validate against.
+
+## Architecture Target
+
+- Synth public packages expose stable AST contracts, parser options, traversal
+  helpers, query primitives, and fixtures.
+- Generated metadata describes package capability, language coverage, runtime
+  requirements, and benchmark status.
+- Rust/WASM bridge outputs are treated as public package surfaces when consumed
+  by Rust-native MCP products.
+- Product repos use official Rust MCP SDK servers and consume Synth only through
+  public packages, generated schemas, fixtures, or documented Rust/WASM outputs.
+- No product imports Synth workspace internals.
+
+## Roadmap
+
+### Phase 0: Boundary And Decision
+
+- Record Synth's role as MCP-family AST foundation.
+- Make explicit that Synth is not an MCP runtime and will not add a TypeScript
+  MCP adapter.
+- Link the role from project manifests and docs.
+
+Exit gate: ADR and project manifests land with JSON/whitespace validation.
+
+### Phase 1: Generated Capability Catalog
+
+- Generate a catalog from `packages/*/package.json`.
+- Include language, package name, runtime requirements, parser mode, WASM usage,
+  benchmark group, and public exports.
+- Use the generated catalog as the source for family docs and product planning.
+
+Exit gate: catalog generation/check runs in CI and fails drift.
+
+### Phase 2: Contract Fixtures
+
+- Add cross-language AST fixtures for imports, exports, symbols, classes,
+  functions, doc comments, markdown headings, tables, links, code blocks, and
+  frontmatter.
+- Add source-span invariants and expected query results.
+- Keep fixtures product-neutral; product-specific labels belong in consuming
+  repos.
+
+Exit gate: fixture test suite proves stable parse output and query behavior.
+
+### Phase 3: Rust/WASM Consumption Path
+
+- Define the supported path for Rust-native MCP products to consume Synth
+  output: package API, generated fixture files, WASM component, Rust crate, or
+  offline generated index.
+- Benchmark startup cost, parse latency, memory ceiling, and binary/package
+  footprint for each viable path.
+- Prefer the simplest path that keeps Rust MCP runtime installation reliable.
+
+Exit gate: at least one Rust-native consumer path is benchmarked and documented
+  without private workspace imports.
+
+### Phase 4: Portfolio Conformance
+
+- `architecture-reader-mcp` validates evidence graph extraction against Synth
+  fixtures.
+- `coderag` validates chunking and symbol-neighborhood behavior against Synth
+  fixtures.
+- reader products validate structured text evidence where Synth owns the parser
+  contract.
+- Mission Control tracks consumption proof as Work Items and links PR/CI
+  readback.
+
+Exit gate: each consuming product has its own tests and ADR/reference to the
+  Synth contract it uses.
+
+## Performance Bar
+
+- Parser output must be deterministic for unchanged input.
+- Source spans must remain stable across minor package releases unless an ADR
+  records the migration.
+- Incremental parsing must prove token/node reuse where advertised.
+- Benchmark claims must be backed by checked benchmark artifacts or generated
+  reports.
+- Runtime consumption paths must not make MCP server install fragile.
+
+## Non-Goals
+
+- Build an MCP server inside Synth.
+- Add a TypeScript MCP adapter for product repos.
+- Encode repository-architecture, search-ranking, filesystem policy, or
+  consultation semantics inside Synth core.
+- Let product repos import private Synth workspace modules.

--- a/docs/roadmap/mcp-family-ast-foundation.md
+++ b/docs/roadmap/mcp-family-ast-foundation.md
@@ -1,6 +1,6 @@
 # MCP Family AST Foundation Roadmap
 
-Decision record: `docs/adr/ADR-DRAFT-mcp-family-ast-foundation.md`
+Decision record: `docs/adr/ADR-35-mcp-family-ast-foundation.md`
 
 Synth is the AST substrate for the Sylphx MCP family. It should make source
 structure fast, stable, and portable for Rust-native MCP products without

--- a/project.manifest.json
+++ b/project.manifest.json
@@ -4,12 +4,20 @@
   "project": {
     "id": "synth",
     "name": "Synth",
-    "summary": "Universal AST processing and language-tooling monorepo for the @sylphx/synth package family, parser packages, AST tooling, and WASM parser bridges.",
+    "summary": "Universal AST processing and language-tooling monorepo for the @sylphx/synth package family, parser packages, AST tooling, WASM parser bridges, and product-neutral AST contracts for Rust-native MCP consumers.",
     "lifecycle": "production",
     "visibility": "open-source",
     "repository": "https://github.com/SylphxAI/synth",
     "homepage": "https://github.com/SylphxAI/synth",
-    "tags": ["typescript", "ast", "parser", "language-tooling", "wasm", "foundation-library"]
+    "tags": [
+      "typescript",
+      "ast",
+      "parser",
+      "language-tooling",
+      "wasm",
+      "foundation-library",
+      "mcp-family-foundation"
+    ]
   },
   "truth": {
     "humanProjectFile": "PROJECT.md",
@@ -63,6 +71,12 @@
       "name": "Documentation site",
       "path": "docs/",
       "description": "VitePress guide, API references, examples, and package documentation."
+    },
+    {
+      "type": "docs",
+      "name": "MCP family AST foundation roadmap",
+      "path": "docs/roadmap/mcp-family-ast-foundation.md",
+      "description": "Roadmap for serving Rust-native MCP products with Synth AST contracts, fixtures, benchmarks, and Rust/WASM bridge criteria."
     },
     {
       "type": "workflow",


### PR DESCRIPTION
## Summary
- define Synth as the product-neutral AST foundation for the Rust-native MCP family
- add ADR-35 and roadmap for generated package catalog, AST fixtures, Rust/WASM consumption, and portfolio conformance
- update project manifests without adding any MCP server or TypeScript MCP adapter to Synth

## Validation
- python3 -m json.tool .doctrine/project.json
- python3 -m json.tool project.manifest.json
- git diff --check
- bundled Node.js --test test/project-control.node-test.mjs
- groundatlas@0.1.3 update + fleet --require-atlas --strict --json
- PATH="/Users/kyle/.cargo/bin:/Users/kyle/.codex/tmp/arg0/codex-arg0rTcfpj:/Users/kyle/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/kyle/.grok/bin:/Users/kyle/.local/bin:/Users/kyle/.bun/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/homebrew/bin:/Users/kyle/.cargo/bin:/Users/kyle/.orbstack/bin:/Applications/Codex.app/Contents/Resources" bun run validate

## Current blocker
- Remote CI is queued on Sylphx self-hosted runner labels [self-hosted, sylphx, linux, standard] with no runner assigned yet. Local validation passed; merge still requires protected checks.