### PR TITLE
docs: clarify AST and Synth MCP family boundaries

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -6,16 +6,17 @@
     "name": "Synth",
     "lifecycle": "production",
     "layer": "foundation",
-    "summary": "Universal AST processing and language-tooling monorepo for the @sylphx/synth package family.",
+    "summary": "Universal AST processing and language-tooling monorepo for the @sylphx/synth* package family.",
     "goals": [
-      "Provide a fast universal AST substrate for parsing, traversal, querying, and language tooling.",
-      "Publish the @sylphx/synth package family for core AST primitives, language parsers, WASM bridges, and AST-based tooling.",
+      "Provide a fast universal AST substrate for parsing, traversal, querying, and language tooling through the @sylphx/synth* package family.",
+      "Publish the @sylphx/synth* package family for core AST primitives, language parsers, WASM bridges, and AST-based tooling.",
       "Keep parser and tooling package contracts stable enough for downstream products to consume through public package exports.",
       "Serve the Rust-native MCP family as a product-neutral AST foundation through public packages, generated contracts, fixtures, benchmarks, and Rust/WASM bridge outputs."
     ],
     "nonGoals": [
       "Own application-specific content workflows, user interfaces, billing, auth, or runtime deployment behavior.",
       "Hardcode consumer-specific syntax behavior or product-only AST semantics into shared parser cores.",
+      "Own ANTLR-backed @sylphlab/ast-* parser contracts that belong in SylphxAI/ast.",
       "Own MCP server runtime, transport, tool schemas, install packaging, or product roadmaps for downstream MCP repositories.",
       "Own Sylphx Platform CI runner, preview, deployment, or production environment control planes."
     ]
@@ -48,7 +49,7 @@
     "publicSurfaces": [
       {
         "type": "package-export",
-        "name": "@sylphx/synth package family",
+        "name": "@sylphx/synth* package family",
         "location": "packages/*/package.json"
       },
       {
@@ -139,6 +140,11 @@
         "direction": "peer-public"
       },
       {
+        "repo": "SylphxAI/ast",
+        "surface": "Public @sylphlab/ast-* ANTLR parser-contract packages, grammar fixtures, and typed source-span contracts.",
+        "direction": "peer-public"
+      },
+      {
         "repo": "actions/setup-node",
         "surface": "GitHub Action for Node.js setup used by GroundAtlas package execution.",
         "direction": "external"
@@ -148,6 +154,7 @@
       "Do not add product-specific parser behavior for a single downstream repository.",
       "Do not make Synth packages depend on application repositories or customer runtime state.",
       "Do not bypass public package exports by having consumers import private workspace internals.",
+      "Do not make Synth claim ownership of SylphxAI/ast @sylphlab/ast-* parser contracts.",
       "Do not add a TypeScript MCP adapter to Synth as the runtime strategy for downstream products.",
       "Do not move Platform preview, deployment, billing, auth, or runner policy into this repository."
     ]

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,9 +1,9 @@
 # Synth
 
 Synth is the Sylphx universal AST processing and language-tooling monorepo. It
-owns the `@sylphx/synth` package family, language parser packages, AST traversal
-and query primitives, WASM parser bridges, and tooling packages for formatting,
-minification, linting, metrics, and documentation generation.
+owns the `@sylphx/synth*` package family, language parser packages, AST
+traversal and query primitives, WASM parser bridges, and tooling packages for
+formatting, minification, linting, metrics, and documentation generation.
 
 Project identity is split by boundary: vendor-neutral project facts live in
 [`project.manifest.json`](./project.manifest.json), while Sylphx-specific governance facts live in
@@ -16,7 +16,8 @@ Project identity is split by boundary: vendor-neutral project facts live in
 
 ## Goals
 
-- Provide a fast, shared universal AST substrate for Sylphx and external users.
+- Provide a fast, shared universal AST substrate for Sylphx and external users
+  through the `@sylphx/synth*` package family.
 - Publish the `@sylphx/synth*` npm package family for parsers and AST tooling.
 - Keep parser/tooling package boundaries clean so downstream applications can
   consume public package exports without repo-internal knowledge.
@@ -30,6 +31,8 @@ Project identity is split by boundary: vendor-neutral project facts live in
   deployment belong outside this repository.
 - Consumer-specific syntax hacks or product-only AST behavior do not belong in
   Synth core packages.
+- ANTLR-backed `@sylphlab/ast-*` parser contracts belong in
+  `SylphxAI/ast`, not in Synth.
 - MCP server runtime, transport, tool schemas, install packaging, and product
   roadmaps belong in the owning MCP repositories, not in Synth.
 - Sylphx Platform CI, preview, deploy, and runner ownership remain outside this
@@ -38,9 +41,11 @@ Project identity is split by boundary: vendor-neutral project facts live in
 ## Boundary Summary
 
 Synth owns AST contracts, parser implementations, package exports, docs for the
-package family, and benchmark/tooling surfaces directly tied to Synth packages.
-Consumers use the published packages and documentation; they do not reach into
-workspace internals or couple product behavior to private parser modules.
+package family, and benchmark/tooling surfaces directly tied to
+`@sylphx/synth*` packages. `SylphxAI/ast` owns the separate
+`@sylphlab/ast-*` ANTLR parser-contract line. Consumers use published packages
+and documentation; they do not reach into workspace internals or couple product
+behavior to private parser modules.
 
 ## Public Surfaces
 

--- a/docs/adr/ADR-35-mcp-family-ast-foundation.md
+++ b/docs/adr/ADR-35-mcp-family-ast-foundation.md
@@ -7,8 +7,8 @@ slug: mcp-family-ast-foundation
 
 ## Context
 
-Synth owns the public AST substrate for Sylphx parser, traversal, query,
-tooling, and WASM parser surfaces. The MCP family now needs a consistent way for
+Synth owns the public `@sylphx/synth*` AST package substrate for Sylphx parser,
+traversal, query, tooling, and WASM parser surfaces. The MCP family now needs a consistent way for
 repository architecture, code retrieval, reader evidence, filesystem, and
 consultation tools to reason about source structure without each product
 inventing its own parser contracts.
@@ -22,7 +22,8 @@ MCP products can consume through public, versioned surfaces.
 
 ## Decision
 
-Synth will serve the MCP family as the AST foundation, not as an MCP runtime.
+Synth will serve the MCP family as the `@sylphx/synth*` universal AST
+foundation, not as an MCP runtime.
 
 Synth owns:
 
@@ -41,14 +42,23 @@ roadmaps. Rust-native MCP servers may use Synth packages, generated schemas,
 fixtures, or Rust/WASM bridge outputs, but must not import Synth workspace
 internals or make Synth aware of product-specific workflows.
 
+## Amendment: AST Repository Boundary
+
+`SylphxAI/ast` owns the separate `@sylphlab/ast-*` ANTLR-backed typed parser
+contract line. Synth must not claim ownership of those packages or their grammar
+fixtures. Downstream MCP products that need parser evidence should evaluate AST
+and Synth through explicit fixtures, benchmarks, source-span conformance, and
+release artifacts rather than importing either workspace's private internals.
+
 TypeScript remains acceptable inside Synth for existing package implementation
 and public JavaScript package delivery. It is not a target MCP adapter layer for
 the Sylphx MCP family.
 
 ## Consequences
 
-- Architecture and code-intelligence products get one shared AST vocabulary
-  without coupling Synth to their runtime decisions.
+- Architecture and code-intelligence products get stable AST vocabularies from
+  public package families without coupling Synth or AST to their runtime
+  decisions.
 - Rust-native MCP products can validate their indexing, chunking, evidence, and
   navigation behavior against Synth fixtures instead of duplicating ad hoc
   parser expectations.

--- a/docs/roadmap/mcp-family-ast-foundation.md
+++ b/docs/roadmap/mcp-family-ast-foundation.md
@@ -2,9 +2,14 @@
 
 Decision record: `docs/adr/ADR-35-mcp-family-ast-foundation.md`
 
-Synth is the AST substrate for the Sylphx MCP family. It should make source
-structure fast, stable, and portable for Rust-native MCP products without
-becoming an MCP server itself.
+Synth is the `@sylphx/synth*` universal AST substrate for the Sylphx MCP family.
+It should make source structure fast, stable, and portable for Rust-native MCP
+products without becoming an MCP server itself.
+
+`SylphxAI/ast` owns the separate `@sylphlab/ast-*` ANTLR-backed typed parser
+contract line. The two foundations must be evaluated through public package
+exports, fixtures, benchmarks, and source-span conformance rather than private
+workspace coupling.
 
 ## Role In The Family
 
@@ -26,6 +31,8 @@ AST contracts they validate against.
 
 - Synth public packages expose stable AST contracts, parser options, traversal
   helpers, query primitives, and fixtures.
+- AST public packages expose ANTLR-backed typed parser contracts and grammar
+  fixtures for the `@sylphlab/ast-*` package line.
 - Generated metadata describes package capability, language coverage, runtime
   requirements, and benchmark status.
 - Rust/WASM bridge outputs are treated as public package surfaces when consumed
@@ -80,9 +87,9 @@ Exit gate: at least one Rust-native consumer path is benchmarked and documented
 ### Phase 4: Portfolio Conformance
 
 - `architecture-reader-mcp` validates evidence graph extraction against Synth
-  fixtures.
+  and AST fixtures where each substrate is selected.
 - `coderag` validates chunking and symbol-neighborhood behavior against Synth
-  fixtures.
+  and AST fixtures where each substrate is selected.
 - reader products validate structured text evidence where Synth owns the parser
   contract.
 - Mission Control tracks consumption proof as Work Items and links PR/CI
@@ -108,3 +115,4 @@ Exit gate: each consuming product has its own tests and ADR/reference to the
 - Encode repository-architecture, search-ranking, filesystem policy, or
   consultation semantics inside Synth core.
 - Let product repos import private Synth workspace modules.
+- Claim ownership of `SylphxAI/ast` `@sylphlab/ast-*` parser contracts.

--- a/project.manifest.json
+++ b/project.manifest.json
@@ -4,7 +4,7 @@
   "project": {
     "id": "synth",
     "name": "Synth",
-    "summary": "Universal AST processing and language-tooling monorepo for the @sylphx/synth package family, parser packages, AST tooling, WASM parser bridges, and product-neutral AST contracts for Rust-native MCP consumers.",
+    "summary": "Universal AST processing and language-tooling monorepo for the @sylphx/synth* package family, parser packages, AST tooling, WASM parser bridges, and product-neutral Synth contracts for Rust-native MCP consumers.",
     "lifecycle": "production",
     "visibility": "open-source",
     "repository": "https://github.com/SylphxAI/synth",
@@ -50,7 +50,7 @@
   "surfaces": [
     {
       "type": "package",
-      "name": "@sylphx/synth package family",
+      "name": "@sylphx/synth* package family",
       "path": "packages/*/package.json",
       "description": "Public parser, AST, tooling, documentation, and WASM package surfaces."
     },
@@ -76,7 +76,7 @@
       "type": "docs",
       "name": "MCP family AST foundation roadmap",
       "path": "docs/roadmap/mcp-family-ast-foundation.md",
-      "description": "Roadmap for serving Rust-native MCP products with Synth AST contracts, fixtures, benchmarks, and Rust/WASM bridge criteria."
+      "description": "Roadmap for serving Rust-native MCP products with @sylphx/synth* contracts, fixtures, benchmarks, and Rust/WASM bridge criteria without claiming SylphxAI/ast ownership."
     },
     {
       "type": "workflow",


### PR DESCRIPTION
## Summary
- clarify that Synth owns the @sylphx/synth* universal AST package family, not SylphxAI/ast's @sylphlab/ast-* ANTLR parser-contract line
- amend ADR-35 and the MCP family roadmap to require fixture/benchmark/source-span evaluation across AST substrates
- update PROJECT and manifests so implementation agents do not create private cross-repo imports or TypeScript MCP adapters

## Validation
- git diff --check
- python3 -m json.tool .doctrine/project.json >/dev/null && python3 -m json.tool project.manifest.json >/dev/null && python3 -m json.tool package.json >/dev/null
- /Users/kyle/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test test/project-control.node-test.mjs
- bun run validate