### PR TITLE
feat(offline): bulk pure residual — AST/metrics/lint (FLEET-BULK-SYNTH-v1)

### DIFF
--- a/crates/core/fixtures/incremental_batch_golden.json
+++ b/crates/core/fixtures/incremental_batch_golden.json
@@ -1,0 +1,190 @@
+{
+  "schema": "synth-incremental-batch-golden/v1",
+  "source": "packages/synth/src/incremental.ts + batch-processor.ts pure helpers",
+  "language": "text",
+  "sourceText": "abcd\nefgh",
+  "nodes": [
+    {
+      "id": 0,
+      "type": "root",
+      "parent": null,
+      "children": [
+        1,
+        2
+      ],
+      "span": {
+        "start": {
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 4,
+          "offset": 9
+        }
+      }
+    },
+    {
+      "id": 1,
+      "type": "left",
+      "parent": 0,
+      "children": [],
+      "span": {
+        "start": {
+          "line": 0,
+          "column": 0,
+          "offset": 0
+        },
+        "end": {
+          "line": 0,
+          "column": 4,
+          "offset": 4
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "right",
+      "parent": 0,
+      "children": [],
+      "span": {
+        "start": {
+          "line": 1,
+          "column": 0,
+          "offset": 5
+        },
+        "end": {
+          "line": 1,
+          "column": 4,
+          "offset": 9
+        }
+      }
+    }
+  ],
+  "cases": [
+    {
+      "name": "ranges_overlap_yes",
+      "kind": "ranges_overlap",
+      "a": [
+        0,
+        5
+      ],
+      "b": [
+        3,
+        8
+      ],
+      "expected": true
+    },
+    {
+      "name": "ranges_overlap_no",
+      "kind": "ranges_overlap",
+      "a": [
+        0,
+        2
+      ],
+      "b": [
+        3,
+        5
+      ],
+      "expected": false
+    },
+    {
+      "name": "offset_to_position_mid_line2",
+      "kind": "offset_to_position",
+      "offset": 6,
+      "expectedPosition": {
+        "line": 1,
+        "column": 1,
+        "offset": 6
+      }
+    },
+    {
+      "name": "plan_edit_left_region",
+      "kind": "plan_edits",
+      "simpleEdits": [
+        {
+          "start": 1,
+          "oldLength": 2,
+          "newLength": 1
+        }
+      ],
+      "expectedAffectedIds": [
+        0,
+        1
+      ],
+      "expectedRange": {
+        "startByte": 1,
+        "endByte": 2
+      }
+    },
+    {
+      "name": "find_node_at_offset_first_hit_root",
+      "kind": "find_node_at_offset",
+      "offset": 6,
+      "expectedId": 0,
+      "note": "TS findNodeAtOffset returns first matching arena index; root spans whole doc"
+    },
+    {
+      "name": "batch_preorder",
+      "kind": "batch_preorder",
+      "expectedIds": [
+        0,
+        1,
+        2
+      ]
+    },
+    {
+      "name": "group_by_type_left",
+      "kind": "group_by_type",
+      "type": "left",
+      "expectedIds": [
+        1
+      ]
+    },
+    {
+      "name": "chunk_size_2",
+      "kind": "chunk",
+      "batchSize": 2,
+      "expectedBatches": [
+        [
+          0,
+          1
+        ],
+        [
+          2
+        ]
+      ]
+    },
+    {
+      "name": "plan_batches_flat_size_2",
+      "kind": "plan_batches",
+      "batchSize": 2,
+      "groupByType": false,
+      "expectedBatches": [
+        [
+          0,
+          1
+        ],
+        [
+          2
+        ]
+      ]
+    },
+    {
+      "name": "find_node_at_offset_only_right_if_we_check_ids",
+      "kind": "find_overlapping_only",
+      "simpleEdits": [
+        {
+          "start": 6,
+          "oldLength": 1,
+          "newLength": 1
+        }
+      ],
+      "expectedAffectedIds": [
+        0,
+        2
+      ]
+    }
+  ]
+}

--- a/crates/core/fixtures/traverse_golden.json
+++ b/crates/core/fixtures/traverse_golden.json
@@ -1,0 +1,53 @@
+{
+  "schema": "synth-traverse-golden/v1",
+  "source": "src/core/traverse.ts + zipper.ts pure id walks",
+  "language": "markdown",
+  "sourceText": "# hi",
+  "nodes": [
+    { "id": 0, "type": "root", "parent": null, "children": [1, 2] },
+    { "id": 1, "type": "heading", "parent": 0, "children": [] },
+    { "id": 2, "type": "paragraph", "parent": 0, "children": [3] },
+    { "id": 3, "type": "text", "parent": 2, "children": [] }
+  ],
+  "cases": [
+    {
+      "name": "pre_order",
+      "order": "pre",
+      "expectedIds": [0, 1, 2, 3]
+    },
+    {
+      "name": "post_order",
+      "order": "post",
+      "expectedIds": [1, 3, 2, 0]
+    },
+    {
+      "name": "breadth_first",
+      "order": "bfs",
+      "expectedIds": [0, 1, 2, 3]
+    },
+    {
+      "name": "max_depth_1_pre",
+      "order": "pre",
+      "maxDepth": 1,
+      "expectedIds": [0, 1, 2]
+    },
+    {
+      "name": "find_by_type_text",
+      "query": "find_by_type",
+      "type": "text",
+      "expectedIds": [3]
+    },
+    {
+      "name": "descendants_of_root",
+      "query": "descendants",
+      "start": 0,
+      "expectedIds": [1, 2, 3]
+    },
+    {
+      "name": "depth_of_text",
+      "query": "depth",
+      "start": 3,
+      "expectedDepth": 2
+    }
+  ]
+}

--- a/crates/core/src/batch.rs
+++ b/crates/core/src/batch.rs
@@ -1,0 +1,149 @@
+//! Pure batch-processing helpers (BW1 residual deepen for core/incremental-batch).
+//!
+//! Parity target: pure grouping/chunking from `packages/synth/src/batch-processor.ts`.
+//! Visitor callbacks stay at the call site (no wasm Fn bridge this tick).
+
+use crate::tree::{NodeId, Tree};
+use crate::traverse::{collect_ids, TraversalOrder};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Default batch size (TS DEFAULT_BATCH_SIZE = 16).
+pub const DEFAULT_BATCH_SIZE: usize = 16;
+
+/// Options for batch chunking (parity with TS BatchProcessingOptions pure subset).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchProcessingOptions {
+    pub batch_size: usize,
+    pub group_by_type: bool,
+}
+
+impl Default for BatchProcessingOptions {
+    fn default() -> Self {
+        Self {
+            batch_size: DEFAULT_BATCH_SIZE,
+            group_by_type: true,
+        }
+    }
+}
+
+/// Group node ids by their type string (sorted keys for stability).
+#[must_use]
+pub fn group_node_ids_by_type(tree: &Tree, node_ids: &[NodeId]) -> BTreeMap<String, Vec<NodeId>> {
+    let mut grouped: BTreeMap<String, Vec<NodeId>> = BTreeMap::new();
+    for &id in node_ids {
+        if let Ok(node) = tree.get_node(id) {
+            grouped
+                .entry(node.node_type.clone())
+                .or_default()
+                .push(id);
+        }
+    }
+    grouped
+}
+
+/// Split a slice into batches of `batch_size` (last may be shorter).
+#[must_use]
+pub fn chunk_ids(ids: &[NodeId], batch_size: usize) -> Vec<Vec<NodeId>> {
+    let size = batch_size.max(1);
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < ids.len() {
+        let end = (i + size).min(ids.len());
+        out.push(ids[i..end].to_vec());
+        i = end;
+    }
+    out
+}
+
+/// Pre-order collect of all node ids (parity with batchTraverse collect phase).
+#[must_use]
+pub fn batch_preorder_ids(tree: &Tree) -> Vec<NodeId> {
+    collect_ids(tree, tree.root_id(), TraversalOrder::PreOrder)
+}
+
+/// Pure plan: either type-grouped batches or flat batches of ids.
+/// Returns ordered list of (optional type key, batch of ids).
+#[must_use]
+pub fn plan_batches(
+    tree: &Tree,
+    node_ids: &[NodeId],
+    options: BatchProcessingOptions,
+) -> Vec<(Option<String>, Vec<NodeId>)> {
+    let size = options.batch_size.max(1);
+    if options.group_by_type {
+        let grouped = group_node_ids_by_type(tree, node_ids);
+        let mut plans = Vec::new();
+        for (ty, ids) in grouped {
+            for batch in chunk_ids(&ids, size) {
+                plans.push((Some(ty.clone()), batch));
+            }
+        }
+        plans
+    } else {
+        chunk_ids(node_ids, size)
+            .into_iter()
+            .map(|b| (None, b))
+            .collect()
+    }
+}
+
+/// Select node ids whose type equals `type_name` via batched preorder plan (pure filter).
+#[must_use]
+pub fn batch_select_by_type(tree: &Tree, type_name: &str) -> Vec<NodeId> {
+    batch_preorder_ids(tree)
+        .into_iter()
+        .filter(|&id| {
+            tree.get_node(id)
+                .map(|n| n.node_type == type_name)
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::Node;
+
+    fn sample() -> Tree {
+        let mut tree = Tree::new("markdown", "# hi");
+        let root = tree.root_id();
+        let h = tree.add_node(Node::new(0, "heading"));
+        let p = tree.add_node(Node::new(0, "paragraph"));
+        let t = tree.add_node(Node::new(0, "text"));
+        let _ = tree.add_child(root, h);
+        let _ = tree.add_child(root, p);
+        let _ = tree.add_child(p, t);
+        tree
+    }
+
+    #[test]
+    fn group_and_chunk() {
+        let tree = sample();
+        let ids = batch_preorder_ids(&tree);
+        assert_eq!(ids, vec![0, 1, 2, 3]);
+        let grouped = group_node_ids_by_type(&tree, &ids);
+        assert_eq!(grouped.get("text").unwrap(), &vec![3]);
+        let chunks = chunk_ids(&ids, 2);
+        assert_eq!(chunks, vec![vec![0, 1], vec![2, 3]]);
+    }
+
+    #[test]
+    fn plan_batches_grouped() {
+        let tree = sample();
+        let ids = batch_preorder_ids(&tree);
+        let plans = plan_batches(
+            &tree,
+            &ids,
+            BatchProcessingOptions {
+                batch_size: 1,
+                group_by_type: true,
+            },
+        );
+        // BTreeMap order: heading, paragraph, root, text
+        assert_eq!(plans.len(), 4);
+        assert_eq!(batch_select_by_type(&tree, "heading"), vec![1]);
+    }
+}

--- a/crates/core/src/complexity_types.rs
+++ b/crates/core/src/complexity_types.rs
@@ -1,0 +1,122 @@
+//! Pure decision/nesting node type classification —
+//! mirrors `packages/synth-metrics/src/analyzer.ts` isDecisionNode/isNestingNode.
+//! FLEET-PRODUCTS-WAVE6 pure residual. NO authority_rust / ts_deleted.
+//! AST traversal remains TS; this is the pure type-name kernel only.
+
+/// Decision-point type fragments (lowercase substring match).
+const DECISION_TYPES: &[&str] = &[
+    "if", "switch", "case", "catch", "&&", "||", "?", "for", "while",
+];
+
+/// Nesting-increasing type fragments (lowercase substring match).
+const NESTING_TYPES: &[&str] = &[
+    "if", "for", "while", "do", "switch", "function", "method", "class",
+];
+
+/// Expanded decision types used by countDecisionPoints (broader set).
+const DECISION_COUNT_TYPES: &[&str] = &[
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "switch",
+    "case",
+    "catch",
+    "and",
+    "or",
+    "&&",
+    "||",
+    "?",
+    "conditionalexpression",
+    "ifstatement",
+    "forstatement",
+    "whilestatement",
+    "dowhilestatement",
+    "switchcase",
+    "catchclause",
+    "logicalexpression",
+];
+
+/// True when node type string is a decision point (isDecisionNode).
+#[must_use]
+pub fn is_decision_node_type(node_type: &str) -> bool {
+    let lower = node_type.to_ascii_lowercase();
+    DECISION_TYPES
+        .iter()
+        .any(|t| lower.contains(t))
+}
+
+/// True when node type increases nesting (isNestingNode).
+#[must_use]
+pub fn is_nesting_node_type(node_type: &str) -> bool {
+    let lower = node_type.to_ascii_lowercase();
+    NESTING_TYPES
+        .iter()
+        .any(|t| lower.contains(t))
+}
+
+/// True when node type counts toward decision-point tally (countDecisionPoints).
+#[must_use]
+pub fn is_decision_count_type(node_type: &str) -> bool {
+    let lower = node_type.to_ascii_lowercase();
+    DECISION_COUNT_TYPES
+        .iter()
+        .any(|t| lower.contains(t))
+}
+
+/// Cyclomatic complexity from decision-point count: decisions + 1.
+#[must_use]
+pub fn cyclomatic_from_decisions(decision_points: u32) -> u32 {
+    decision_points.saturating_add(1)
+}
+
+/// Cognitive complexity contribution for a decision at nesting depth.
+/// Parity: complexity += 1 + nesting when isDecision.
+#[must_use]
+pub fn cognitive_decision_weight(nesting: u32) -> u32 {
+    1u32.saturating_add(nesting)
+}
+
+/// Next nesting depth after visiting a node.
+#[must_use]
+pub fn next_nesting(current: u32, node_type: &str) -> u32 {
+    if is_nesting_node_type(node_type) {
+        current.saturating_add(1)
+    } else {
+        current
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decision_and_nesting_types() {
+        assert!(is_decision_node_type("IfStatement"));
+        assert!(is_decision_node_type("LogicalExpression"));
+        assert!(is_decision_node_type("for"));
+        assert!(!is_decision_node_type("Identifier"));
+        assert!(is_nesting_node_type("FunctionDeclaration"));
+        assert!(is_nesting_node_type("WhileStatement"));
+        assert!(!is_nesting_node_type("Literal"));
+    }
+
+    #[test]
+    fn count_types_broader() {
+        assert!(is_decision_count_type("ElseClause"));
+        assert!(is_decision_count_type("CatchClause"));
+        assert!(is_decision_count_type("ConditionalExpression"));
+    }
+
+    #[test]
+    fn cyclomatic_and_cognitive() {
+        assert_eq!(cyclomatic_from_decisions(0), 1);
+        assert_eq!(cyclomatic_from_decisions(3), 4);
+        assert_eq!(cognitive_decision_weight(0), 1);
+        assert_eq!(cognitive_decision_weight(2), 3);
+        assert_eq!(next_nesting(0, "if"), 1);
+        assert_eq!(next_nesting(1, "Identifier"), 1);
+    }
+}

--- a/crates/core/src/complexity_types.rs
+++ b/crates/core/src/complexity_types.rs
@@ -94,13 +94,19 @@ mod tests {
 
     #[test]
     fn decision_and_nesting_types() {
+        // TS isDecisionNode uses short fragment list with includes()
         assert!(is_decision_node_type("IfStatement"));
-        assert!(is_decision_node_type("LogicalExpression"));
         assert!(is_decision_node_type("for"));
-        assert!(!is_decision_node_type("Identifier"));
+        assert!(is_decision_node_type("WhileStatement"));
+        assert!(is_decision_node_type("SwitchCase"));
+        // LogicalExpression is NOT in the short isDecisionNode list
+        assert!(!is_decision_node_type("LogicalExpression"));
+        // Identifier contains "if" substring — TS includes() true; keep parity
+        assert!(is_decision_node_type("Identifier"));
         assert!(is_nesting_node_type("FunctionDeclaration"));
         assert!(is_nesting_node_type("WhileStatement"));
         assert!(!is_nesting_node_type("Literal"));
+        assert!(!is_nesting_node_type("StringLiteral"));
     }
 
     #[test]
@@ -108,6 +114,7 @@ mod tests {
         assert!(is_decision_count_type("ElseClause"));
         assert!(is_decision_count_type("CatchClause"));
         assert!(is_decision_count_type("ConditionalExpression"));
+        assert!(is_decision_count_type("LogicalExpression"));
     }
 
     #[test]
@@ -117,6 +124,9 @@ mod tests {
         assert_eq!(cognitive_decision_weight(0), 1);
         assert_eq!(cognitive_decision_weight(2), 3);
         assert_eq!(next_nesting(0, "if"), 1);
-        assert_eq!(next_nesting(1, "Identifier"), 1);
+        // "Identifier" contains "if" → nesting match (TS includes parity)
+        assert_eq!(next_nesting(1, "Identifier"), 2);
+        // clean non-nesting type without decision substrings
+        assert_eq!(next_nesting(1, "StringLiteral"), 1);
     }
 }

--- a/crates/core/src/detect_language.rs
+++ b/crates/core/src/detect_language.rs
@@ -1,0 +1,84 @@
+//! Pure language detection from URI extension — mirrors
+//! `packages/synth/src/incremental-parser-manager.ts#detectLanguage`.
+//! FLEET-PRODUCTS-WAVE7 pure residual. NO authority_rust / ts_deleted.
+
+/// Detect language id from a file URI / path extension.
+#[must_use]
+pub fn detect_language(uri: &str) -> Option<&'static str> {
+    let ext = uri
+        .rsplit('.')
+        .next()
+        .map(|e| e.to_ascii_lowercase())
+        .unwrap_or_default();
+    // no extension (no dot) → None; treat whole string as "ext" only if had a dot
+    if !uri.contains('.') {
+        return None;
+    }
+    match ext.as_str() {
+        "md" | "markdown" => Some("markdown"),
+        "js" | "mjs" => Some("javascript"),
+        "ts" | "mts" => Some("typescript"),
+        "html" | "htm" => Some("html"),
+        "json" => Some("json"),
+        "css" => Some("css"),
+        "yaml" | "yml" => Some("yaml"),
+        "toml" => Some("toml"),
+        "xml" => Some("xml"),
+        _ => None,
+    }
+}
+
+/// Common prefix length between two texts (detectEdit helper pure fragment).
+#[must_use]
+pub fn common_prefix_len(old: &str, new: &str) -> usize {
+    old.bytes()
+        .zip(new.bytes())
+        .take_while(|(a, b)| a == b)
+        .count()
+}
+
+/// Common suffix length after a known prefix start (detectEdit pure fragment).
+#[must_use]
+pub fn common_suffix_len(old: &str, new: &str, start_index: usize) -> usize {
+    let old_b = old.as_bytes();
+    let new_b = new.as_bytes();
+    let mut old_end = old_b.len();
+    let mut new_end = new_b.len();
+    let mut n = 0usize;
+    while old_end > start_index && new_end > start_index {
+        if old_b[old_end - 1] != new_b[new_end - 1] {
+            break;
+        }
+        old_end -= 1;
+        new_end -= 1;
+        n += 1;
+    }
+    n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn language_from_ext() {
+        assert_eq!(detect_language("a/b/c.md"), Some("markdown"));
+        assert_eq!(detect_language("x.MARKDOWN"), Some("markdown"));
+        assert_eq!(detect_language("app.mjs"), Some("javascript"));
+        assert_eq!(detect_language("app.ts"), Some("typescript"));
+        assert_eq!(detect_language("style.css"), Some("css"));
+        assert_eq!(detect_language("cfg.yaml"), Some("yaml"));
+        assert_eq!(detect_language("cfg.yml"), Some("yaml"));
+        assert_eq!(detect_language("noext"), None);
+        assert_eq!(detect_language("file.unknown"), None);
+    }
+
+    #[test]
+    fn prefix_suffix() {
+        assert_eq!(common_prefix_len("hello world", "hello there"), 6);
+        assert_eq!(common_suffix_len("abXYZ", "cdXYZ", 0), 3);
+        assert_eq!(common_suffix_len("abc", "abc", 0), 3);
+        // when start cuts into suffix
+        assert_eq!(common_suffix_len("aaabbb", "aaaxbb", 3), 2);
+    }
+}

--- a/crates/core/src/halstead_math.rs
+++ b/crates/core/src/halstead_math.rs
@@ -1,0 +1,121 @@
+//! Pure Halstead + maintainability arithmetic — mirrors
+//! `packages/synth-metrics/src/analyzer.ts` formulas (no AST traversal).
+//! FLEET-PRODUCTS-WAVE5 pure residual. NO authority_rust / ts_deleted.
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HalsteadMetrics {
+    pub n1: f64,
+    pub n2: f64,
+    pub n1_total: f64,
+    pub n2_total: f64,
+    pub vocabulary: f64,
+    pub length: f64,
+    pub calculated_length: f64,
+    pub volume: f64,
+    pub difficulty: f64,
+    pub effort: f64,
+    pub time: f64,
+    pub bugs: f64,
+}
+
+/// Compute Halstead metrics from unique/total operator/operand counts.
+#[must_use]
+pub fn compute_halstead(n1: f64, n2: f64, n1_total: f64, n2_total: f64) -> HalsteadMetrics {
+    let vocabulary = n1 + n2;
+    let length = n1_total + n2_total;
+    let calculated_length = n1 * (n1.max(1.0)).log2() + n2 * (n2.max(1.0)).log2();
+    let volume = length * (vocabulary.max(1.0)).log2();
+    let difficulty = (n1 / 2.0) * (n2_total / n2.max(1.0));
+    let effort = difficulty * volume;
+    let time = effort / 18.0;
+    let bugs = effort.powf(2.0 / 3.0) / 3000.0;
+    HalsteadMetrics {
+        n1,
+        n2,
+        n1_total,
+        n2_total,
+        vocabulary,
+        length,
+        calculated_length,
+        volume,
+        difficulty,
+        effort,
+        time,
+        bugs,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaintainabilityLevel {
+    /// index >= 85 — low difficulty to maintain
+    LowDifficulty,
+    /// index >= 65
+    Moderate,
+    /// index >= 20
+    High,
+    /// index < 20
+    VeryHigh,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MaintainabilityMetrics {
+    pub index: f64,
+    pub level: MaintainabilityLevel,
+    pub maintainable: bool,
+}
+
+/// Maintainability Index = 171 - 5.2*ln(V) - 0.23*G - 16.2*ln(LOC), clamped 0..100.
+#[must_use]
+pub fn calculate_maintainability(volume: f64, cyclomatic: f64, loc: f64) -> MaintainabilityMetrics {
+    let v = if volume <= 0.0 { 1.0 } else { volume };
+    let loc = if loc <= 0.0 { 1.0 } else { loc };
+    let mut index = 171.0 - 5.2 * v.ln() - 0.23 * cyclomatic - 16.2 * loc.ln();
+    index = index.clamp(0.0, 100.0);
+    let level = if index >= 85.0 {
+        MaintainabilityLevel::LowDifficulty
+    } else if index >= 65.0 {
+        MaintainabilityLevel::Moderate
+    } else if index >= 20.0 {
+        MaintainabilityLevel::High
+    } else {
+        MaintainabilityLevel::VeryHigh
+    };
+    MaintainabilityMetrics {
+        index,
+        level,
+        maintainable: index >= 20.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn halstead_basic() {
+        let h = compute_halstead(4.0, 5.0, 10.0, 12.0);
+        assert!((h.vocabulary - 9.0).abs() < 1e-12);
+        assert!((h.length - 22.0).abs() < 1e-12);
+        assert!(h.volume > 0.0);
+        assert!(h.effort > 0.0);
+        assert!((h.time - h.effort / 18.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn maintainability_clamps_and_levels() {
+        let m = calculate_maintainability(1.0, 1.0, 1.0);
+        assert!(m.index >= 85.0);
+        assert_eq!(m.level, MaintainabilityLevel::LowDifficulty);
+        assert!(m.maintainable);
+
+        let hard = calculate_maintainability(1_000_000.0, 200.0, 10_000.0);
+        assert!(hard.index < 20.0 || !hard.maintainable || hard.level == MaintainabilityLevel::VeryHigh || hard.level == MaintainabilityLevel::High);
+        assert!((0.0..=100.0).contains(&hard.index));
+    }
+
+    #[test]
+    fn zero_volume_loc_defaults() {
+        let m = calculate_maintainability(0.0, 1.0, 0.0);
+        assert!((0.0..=100.0).contains(&m.index));
+    }
+}

--- a/crates/core/src/incremental.rs
+++ b/crates/core/src/incremental.rs
@@ -1,0 +1,250 @@
+//! Pure incremental-edit geometry (BW1 residual deepen for core/incremental-batch).
+//!
+//! Parity target: pure helpers from `packages/synth/src/incremental.ts`
+//! (edit normalization, range overlap, affected-node detection). Re-parse /
+//! parser callbacks stay TS until a WASM bridge ships. No I/O.
+
+use crate::position::{Position, Span};
+use crate::tree::{NodeId, Tree};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// Text edit description (tree-sitter compatible; parity with TS `Edit`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Edit {
+    pub start_byte: u32,
+    pub old_end_byte: u32,
+    pub new_end_byte: u32,
+    pub start_position: Position,
+    pub old_end_position: Position,
+    pub new_end_position: Position,
+}
+
+/// Simple edit for common cases (parity with TS `SimpleEdit`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SimpleEdit {
+    pub start: u32,
+    pub old_length: u32,
+    pub new_length: u32,
+}
+
+/// Range affected by one or more edits (parity with TS `AffectedRange`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AffectedRange {
+    pub start_byte: u32,
+    pub end_byte: u32,
+    pub start_position: Position,
+    pub end_position: Position,
+}
+
+/// Check if two closed-ish byte ranges overlap (TS: `start1 <= end2 && start2 <= end1`).
+#[must_use]
+pub fn ranges_overlap(start1: u32, end1: u32, start2: u32, end2: u32) -> bool {
+    start1 <= end2 && start2 <= end1
+}
+
+/// Convert byte offset to Position by scanning `source`.
+///
+/// Matches TS `IncrementalParser.offsetToPosition`: line/column start at 0
+/// (TS incremental path; not 1-indexed document convention elsewhere).
+#[must_use]
+pub fn offset_to_position(source: &str, offset: u32) -> Position {
+    let mut line: u32 = 0;
+    let mut column: u32 = 0;
+    let limit = offset as usize;
+    for (i, ch) in source.char_indices() {
+        if i >= limit {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            column = 0;
+        } else {
+            column += 1;
+        }
+    }
+    Position::new(line, column, offset)
+}
+
+/// Normalize SimpleEdit → full Edit using `source` for position fill.
+#[must_use]
+pub fn normalize_simple_edit(source: &str, simple: SimpleEdit) -> Edit {
+    Edit {
+        start_byte: simple.start,
+        old_end_byte: simple.start.saturating_add(simple.old_length),
+        new_end_byte: simple.start.saturating_add(simple.new_length),
+        start_position: offset_to_position(source, simple.start),
+        old_end_position: offset_to_position(source, simple.start.saturating_add(simple.old_length)),
+        new_end_position: offset_to_position(source, simple.start.saturating_add(simple.new_length)),
+    }
+}
+
+/// Find node ids whose span overlaps the edit's old byte range.
+#[must_use]
+pub fn find_overlapping_nodes(tree: &Tree, edit: &Edit) -> Vec<NodeId> {
+    let mut overlapping = Vec::new();
+    for node in tree.nodes() {
+        let Some(span) = node.span else {
+            continue;
+        };
+        let node_start = span.start.offset;
+        let node_end = span.end.offset;
+        if ranges_overlap(node_start, node_end, edit.start_byte, edit.old_end_byte) {
+            overlapping.push(node.id);
+        }
+    }
+    overlapping
+}
+
+/// Walk parents of `node_id` and insert them into `affected` (TS markParentsAsAffected).
+pub fn mark_parents_as_affected(tree: &Tree, node_id: NodeId, affected: &mut BTreeSet<NodeId>) {
+    let Ok(node) = tree.get_node(node_id) else {
+        return;
+    };
+    let Some(parent) = node.parent else {
+        return;
+    };
+    affected.insert(parent);
+    mark_parents_as_affected(tree, parent, affected);
+}
+
+/// Find all nodes affected by edits (overlap + parent chain). Sorted ids for stability.
+#[must_use]
+pub fn find_affected_nodes(tree: &Tree, edits: &[Edit]) -> Vec<NodeId> {
+    let mut affected: BTreeSet<NodeId> = BTreeSet::new();
+    for edit in edits {
+        for id in find_overlapping_nodes(tree, edit) {
+            affected.insert(id);
+            mark_parents_as_affected(tree, id, &mut affected);
+        }
+    }
+    affected.into_iter().collect()
+}
+
+/// Union of edit ranges into a single AffectedRange (TS calculateAffectedRange).
+/// Empty edits → zero range at origin.
+#[must_use]
+pub fn calculate_affected_range(edits: &[Edit]) -> AffectedRange {
+    if edits.is_empty() {
+        let z = Position::new(0, 0, 0);
+        return AffectedRange {
+            start_byte: 0,
+            end_byte: 0,
+            start_position: z,
+            end_position: z,
+        };
+    }
+    let mut min_start = u32::MAX;
+    let mut max_end = 0u32;
+    for edit in edits {
+        min_start = min_start.min(edit.start_byte);
+        max_end = max_end.max(edit.new_end_byte);
+    }
+    AffectedRange {
+        start_byte: min_start,
+        end_byte: max_end,
+        start_position: edits[0].start_position,
+        end_position: edits[edits.len() - 1].new_end_position,
+    }
+}
+
+/// First node index whose span contains `offset` (TS findNodeAtOffset → arena index).
+#[must_use]
+pub fn find_node_at_offset(tree: &Tree, offset: u32) -> Option<NodeId> {
+    for node in tree.nodes() {
+        let Some(span) = node.span else {
+            continue;
+        };
+        if span.start.offset <= offset && offset <= span.end.offset {
+            return Some(node.id);
+        }
+    }
+    None
+}
+
+/// Convenience: apply simple edit list → (normalized edits, affected ids, range).
+#[must_use]
+pub fn plan_edits(tree: &Tree, simple: &[SimpleEdit]) -> (Vec<Edit>, Vec<NodeId>, AffectedRange) {
+    let source = tree.source();
+    let edits: Vec<Edit> = simple
+        .iter()
+        .copied()
+        .map(|s| normalize_simple_edit(&source, s))
+        .collect();
+    let affected = find_affected_nodes(tree, &edits);
+    let range = calculate_affected_range(&edits);
+    (edits, affected, range)
+}
+
+/// Helper to attach a span for tests / fixture loaders.
+pub fn set_node_span(tree: &mut Tree, id: NodeId, span: Span) {
+    if let Ok(node) = tree.get_node_mut(id) {
+        node.span = Some(span);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::Node;
+
+    fn sample_spanned_tree() -> Tree {
+        // source: "abcd\nefgh"  (9 chars + newline = 9? a b c d \n e f g h = 9)
+        // offsets: a0 b1 c2 d3 \n4 e5 f6 g7 h8
+        let mut tree = Tree::new("text", "abcd\nefgh");
+        let root = tree.root_id();
+        let left = tree.add_node(Node::new(0, "left").with_span(Span::from_coords(0, 0, 0, 0, 4, 4)));
+        let right = tree.add_node(
+            Node::new(0, "right").with_span(Span::from_coords(1, 0, 5, 1, 4, 9)),
+        );
+        let _ = tree.add_child(root, left);
+        let _ = tree.add_child(root, right);
+        // root span whole doc
+        set_node_span(
+            &mut tree,
+            root,
+            Span::from_coords(0, 0, 0, 1, 4, 9),
+        );
+        tree
+    }
+
+    #[test]
+    fn ranges_overlap_basic() {
+        assert!(ranges_overlap(0, 5, 3, 8));
+        assert!(!ranges_overlap(0, 2, 3, 5));
+        assert!(ranges_overlap(0, 5, 5, 10)); // boundary inclusive per TS
+    }
+
+    #[test]
+    fn offset_to_position_newlines() {
+        let src = "abcd\nefgh";
+        let p = offset_to_position(src, 6);
+        assert_eq!(p.line, 1);
+        assert_eq!(p.column, 1); // 'f' is col 1 after e at col 0
+        assert_eq!(p.offset, 6);
+    }
+
+    #[test]
+    fn normalize_and_plan_edits() {
+        let tree = sample_spanned_tree();
+        let simple = SimpleEdit {
+            start: 1,
+            old_length: 2,
+            new_length: 1,
+        };
+        let (edits, affected, range) = plan_edits(&tree, &[simple]);
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].start_byte, 1);
+        assert_eq!(edits[0].old_end_byte, 3);
+        assert_eq!(edits[0].new_end_byte, 2);
+        // left (0-4) overlaps, root parent marked
+        assert!(affected.contains(&0));
+        assert!(affected.contains(&1));
+        assert!(!affected.contains(&2)); // right starts at 5
+        assert_eq!(range.start_byte, 1);
+        assert_eq!(range.end_byte, 2);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,7 @@ mod mangle;
 mod halstead_math;
 mod complexity_types;
 mod detect_language;
+mod token_span;
 
 pub use tree::*;
 pub use query::{depth, descendants, find_by_type};
@@ -60,4 +61,5 @@ pub fn core_version() -> String {
 }
 
 pub use detect_language::{common_prefix_len, common_suffix_len, detect_language};
+pub use token_span::{find_token_index_at_offset, format_token_stats, is_position_in_token, token_ranges_overlap, TokenizerStats};
 pub use complexity_types::{cognitive_decision_weight, cyclomatic_from_decisions, is_decision_count_type, is_decision_node_type, is_nesting_node_type, next_nesting};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,6 +9,8 @@ mod error;
 mod position;
 mod traverse;
 mod zipper;
+mod incremental;
+mod batch;
 
 pub use tree::*;
 pub use query::{depth, descendants, find_by_type};
@@ -19,6 +21,15 @@ pub use traverse::{
 };
 pub use zipper::{
     create_zipper, create_zipper_at, down, is_root, left, right, up, zipper_depth, Crumb, Zipper,
+};
+pub use incremental::{
+    calculate_affected_range, find_affected_nodes, find_node_at_offset, find_overlapping_nodes,
+    mark_parents_as_affected, normalize_simple_edit, offset_to_position, plan_edits, ranges_overlap,
+    set_node_span, AffectedRange, Edit, SimpleEdit,
+};
+pub use batch::{
+    batch_preorder_ids, batch_select_by_type, chunk_ids, group_node_ids_by_type, plan_batches,
+    BatchProcessingOptions, DEFAULT_BATCH_SIZE,
 };
 
 use wasm_bindgen::prelude::*;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,10 +4,12 @@
 //! Provides Tree structure compatible with the TypeScript @sylphx/synth package.
 
 mod tree;
+mod query;
 mod error;
 mod position;
 
 pub use tree::*;
+pub use query::{depth, descendants, find_by_type};
 pub use error::*;
 pub use position::*;
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,6 +15,7 @@ mod metrics_basic;
 mod minify_savings;
 mod mangle;
 mod halstead_math;
+mod complexity_types;
 
 pub use tree::*;
 pub use query::{depth, descendants, find_by_type};
@@ -56,3 +57,5 @@ pub fn init() {
 pub fn core_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
+
+pub use complexity_types::{cognitive_decision_weight, cyclomatic_from_decisions, is_decision_count_type, is_decision_node_type, is_nesting_node_type, next_nesting};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,8 @@ mod traverse;
 mod zipper;
 mod incremental;
 mod batch;
+mod metrics_basic;
+mod minify_savings;
 
 pub use tree::*;
 pub use query::{depth, descendants, find_by_type};
@@ -31,6 +33,8 @@ pub use batch::{
     batch_preorder_ids, batch_select_by_type, chunk_ids, group_node_ids_by_type, plan_batches,
     BatchProcessingOptions, DEFAULT_BATCH_SIZE,
 };
+pub use metrics_basic::{analyze_basic_loc, classify_line, BasicLocMetrics, LineKind};
+pub use minify_savings::{compression_ratio, savings, Savings};
 
 use wasm_bindgen::prelude::*;
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,7 @@ mod minify_savings;
 mod mangle;
 mod halstead_math;
 mod complexity_types;
+mod detect_language;
 
 pub use tree::*;
 pub use query::{depth, descendants, find_by_type};
@@ -58,4 +59,5 @@ pub fn core_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
+pub use detect_language::{common_prefix_len, common_suffix_len, detect_language};
 pub use complexity_types::{cognitive_decision_weight, cyclomatic_from_decisions, is_decision_count_type, is_decision_node_type, is_nesting_node_type, next_nesting};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,6 +13,7 @@ mod incremental;
 mod batch;
 mod metrics_basic;
 mod minify_savings;
+mod mangle;
 
 pub use tree::*;
 pub use query::{depth, descendants, find_by_type};
@@ -35,6 +36,7 @@ pub use batch::{
 };
 pub use metrics_basic::{analyze_basic_loc, classify_line, BasicLocMetrics, LineKind};
 pub use minify_savings::{compression_ratio, savings, Savings};
+pub use mangle::{generate_mangled_name, NameMangler};
 
 use wasm_bindgen::prelude::*;
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,6 +14,7 @@ mod batch;
 mod metrics_basic;
 mod minify_savings;
 mod mangle;
+mod halstead_math;
 
 pub use tree::*;
 pub use query::{depth, descendants, find_by_type};
@@ -37,6 +38,10 @@ pub use batch::{
 pub use metrics_basic::{analyze_basic_loc, classify_line, BasicLocMetrics, LineKind};
 pub use minify_savings::{compression_ratio, savings, Savings};
 pub use mangle::{generate_mangled_name, NameMangler};
+pub use halstead_math::{
+    calculate_maintainability, compute_halstead, HalsteadMetrics, MaintainabilityLevel,
+    MaintainabilityMetrics,
+};
 
 use wasm_bindgen::prelude::*;
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,6 +18,7 @@ mod halstead_math;
 mod complexity_types;
 mod detect_language;
 mod token_span;
+mod lint_max_depth;
 
 pub use tree::*;
 pub use query::{depth, descendants, find_by_type};
@@ -63,3 +64,4 @@ pub fn core_version() -> String {
 pub use detect_language::{common_prefix_len, common_suffix_len, detect_language};
 pub use token_span::{find_token_index_at_offset, format_token_stats, is_position_in_token, token_ranges_overlap, TokenizerStats};
 pub use complexity_types::{cognitive_decision_weight, cyclomatic_from_decisions, is_decision_count_type, is_decision_node_type, is_nesting_node_type, next_nesting};
+pub use lint_max_depth::{compute_depth_from_parents, depth_exceeds, max_depth_message, should_report_default, DEFAULT_MAX_DEPTH};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,11 +7,19 @@ mod tree;
 mod query;
 mod error;
 mod position;
+mod traverse;
+mod zipper;
 
 pub use tree::*;
 pub use query::{depth, descendants, find_by_type};
 pub use error::*;
 pub use position::*;
+pub use traverse::{
+    breadth_first, collect_ids, collect_ids_max_depth, post_order, pre_order, TraversalOrder,
+};
+pub use zipper::{
+    create_zipper, create_zipper_at, down, is_root, left, right, up, zipper_depth, Crumb, Zipper,
+};
 
 use wasm_bindgen::prelude::*;
 

--- a/crates/core/src/lint_max_depth.rs
+++ b/crates/core/src/lint_max_depth.rs
@@ -1,0 +1,79 @@
+//! Pure max-depth lint rule helpers — mirrors
+//! `packages/synth-lint/src/rules/max-depth.ts`.
+//! Depth is computed from parent-chain length; no AST visitor engine.
+//! FLEET-BULK pure residual. NO authority_rust / ts_deleted.
+
+pub const DEFAULT_MAX_DEPTH: u32 = 4;
+
+/// Whether nesting depth exceeds the configured max.
+#[must_use]
+pub fn depth_exceeds(depth: u32, max_depth: u32) -> bool {
+    depth > max_depth
+}
+
+/// Warning message parity with TS rule.
+#[must_use]
+pub fn max_depth_message(depth: u32, max_depth: u32) -> String {
+    format!("Nesting depth of {depth} exceeds maximum allowed depth of {max_depth}")
+}
+
+/// Compute depth from a parent-id chain (root has parent None → depth 0).
+/// `parent_of` returns parent id for a node id, or None at root.
+#[must_use]
+pub fn compute_depth_from_parents(start: u32, parent_of: &[(u32, Option<u32>)]) -> u32 {
+    let map: std::collections::HashMap<u32, Option<u32>> =
+        parent_of.iter().copied().collect();
+    let mut depth = 0u32;
+    let mut current = Some(start);
+    let mut guard = 0u32;
+    while let Some(id) = current {
+        if guard > 10_000 {
+            break;
+        }
+        guard += 1;
+        match map.get(&id).copied().flatten() {
+            Some(p) => {
+                depth += 1;
+                current = Some(p);
+            }
+            None => break,
+        }
+    }
+    depth
+}
+
+/// Evaluate whether a node at `depth` should report under DEFAULT_MAX_DEPTH.
+#[must_use]
+pub fn should_report_default(depth: u32) -> bool {
+    depth_exceeds(depth, DEFAULT_MAX_DEPTH)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn depth_rule() {
+        assert!(!depth_exceeds(4, 4));
+        assert!(depth_exceeds(5, 4));
+        assert!(should_report_default(5));
+        assert!(!should_report_default(4));
+        let msg = max_depth_message(6, 4);
+        assert!(msg.contains("6"));
+        assert!(msg.contains("4"));
+    }
+
+    #[test]
+    fn parent_chain() {
+        // 0 root, 1→0, 2→1, 3→2
+        let parents = vec![
+            (0, None),
+            (1, Some(0)),
+            (2, Some(1)),
+            (3, Some(2)),
+        ];
+        assert_eq!(compute_depth_from_parents(0, &parents), 0);
+        assert_eq!(compute_depth_from_parents(1, &parents), 1);
+        assert_eq!(compute_depth_from_parents(3, &parents), 3);
+    }
+}

--- a/crates/core/src/mangle.rs
+++ b/crates/core/src/mangle.rs
@@ -85,4 +85,28 @@ mod tests {
         assert_eq!(m.mangle("baz", false), "baz");
         assert_eq!(m.counter(), 2);
     }
+
+
+    #[test]
+    fn fleet_web_media_wave4_mangle_skips_reserved_and_increments() {
+        let mut m = NameMangler::new(["window".into()]);
+        let a = m.mangle("foo", true);
+        let b = m.mangle("bar", true);
+        assert_ne!(a, b);
+        let a2 = m.mangle("foo", true);
+        assert_eq!(a, a2);
+        assert!(m.counter() >= 2);
+        // disabled returns original
+        assert_eq!(m.mangle("baz", false), "baz");
+    }
+
+    #[test]
+    fn fleet_web_media_wave4_generate_mangled_name_base26ish() {
+        assert_eq!(generate_mangled_name(0), "a");
+        assert_eq!(generate_mangled_name(1), "b");
+        assert_eq!(generate_mangled_name(25), "z");
+        let aa = generate_mangled_name(26);
+        assert!(!aa.is_empty());
+        assert_ne!(aa, "a");
+    }
 }

--- a/crates/core/src/mangle.rs
+++ b/crates/core/src/mangle.rs
@@ -1,0 +1,88 @@
+//! Pure identifier mangling (parity with synth-js-minify Compressor.generateMangledName /
+//! mangleName arithmetic). Residual pure deepen for tooling/format-minify-lint fragment.
+//! No AST transform engine, no authority claims.
+
+/// Generate short mangled names: a, b, ..., z, aa, ab, ...
+/// Parity: `generateMangledName` with counter starting at 0.
+#[must_use]
+pub fn generate_mangled_name(counter: usize) -> String {
+    let alphabet = b"abcdefghijklmnopqrstuvwxyz";
+    let mut num = counter as isize;
+    let mut name = String::new();
+    loop {
+        let idx = (num % 26) as usize;
+        name.insert(0, alphabet[idx] as char);
+        num = num / 26 - 1;
+        if num < 0 {
+            break;
+        }
+    }
+    name
+}
+
+/// Stateful mangler mapping original → short names, respecting reserved set.
+#[derive(Debug, Default, Clone)]
+pub struct NameMangler {
+    counter: usize,
+    map: std::collections::HashMap<String, String>,
+    reserved: std::collections::HashSet<String>,
+}
+
+impl NameMangler {
+    #[must_use]
+    pub fn new(reserved: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            counter: 0,
+            map: std::collections::HashMap::new(),
+            reserved: reserved.into_iter().collect(),
+        }
+    }
+
+    /// Mangle a name (parity: mangleName). If mangling disabled path: pass-through via
+    /// `mangle(name, false)`.
+    pub fn mangle(&mut self, name: &str, enabled: bool) -> String {
+        if !enabled {
+            return name.to_string();
+        }
+        if self.reserved.contains(name) {
+            return name.to_string();
+        }
+        if let Some(existing) = self.map.get(name) {
+            return existing.clone();
+        }
+        let mangled = generate_mangled_name(self.counter);
+        self.counter += 1;
+        self.map.insert(name.to_string(), mangled.clone());
+        mangled
+    }
+
+    #[must_use]
+    pub fn counter(&self) -> usize {
+        self.counter
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sequence_a_to_aa() {
+        assert_eq!(generate_mangled_name(0), "a");
+        assert_eq!(generate_mangled_name(1), "b");
+        assert_eq!(generate_mangled_name(25), "z");
+        assert_eq!(generate_mangled_name(26), "aa");
+        assert_eq!(generate_mangled_name(27), "ab");
+    }
+
+    #[test]
+    fn mangler_stable_and_reserved() {
+        let mut m = NameMangler::new(["window".into(), "document".into()]);
+        assert_eq!(m.mangle("foo", true), "a");
+        assert_eq!(m.mangle("bar", true), "b");
+        assert_eq!(m.mangle("foo", true), "a");
+        assert_eq!(m.mangle("window", true), "window");
+        assert_eq!(m.mangle("baz", false), "baz");
+        assert_eq!(m.counter(), 2);
+    }
+}

--- a/crates/core/src/metrics_basic.rs
+++ b/crates/core/src/metrics_basic.rs
@@ -72,4 +72,28 @@ mod tests {
         let m = analyze_basic_loc("");
         assert_eq!(m, BasicLocMetrics { loc: 0, blank: 0, cloc: 0, sloc: 0 });
     }
+
+    #[test]
+    fn fleet_web_media_wave4_classify_line_kinds() {
+        // classify_line expects already-trimmed input (see analyze_basic_loc).
+        assert_eq!(classify_line(""), LineKind::Blank);
+        assert_eq!(classify_line("// comment"), LineKind::Comment);
+        assert_eq!(classify_line("# python"), LineKind::Comment);
+        assert_eq!(classify_line("/* block"), LineKind::Comment);
+        assert_eq!(classify_line("* cont"), LineKind::Comment);
+        assert_eq!(classify_line("let x = 1;"), LineKind::Code);
+        // untrimmed spaces are NOT blank at this layer
+        assert_eq!(classify_line("   "), LineKind::Code);
+    }
+
+    #[test]
+    fn fleet_web_media_wave4_analyze_mixed_source() {
+        let src = "\n// c\nfn main() {}\n\n";
+        let m = analyze_basic_loc(src);
+        assert!(m.loc >= 4);
+        assert!(m.blank >= 1);
+        assert!(m.cloc >= 1);
+        assert!(m.sloc >= 1);
+        assert_eq!(m.loc, m.blank + m.cloc + m.sloc);
+    }
 }

--- a/crates/core/src/metrics_basic.rs
+++ b/crates/core/src/metrics_basic.rs
@@ -1,0 +1,75 @@
+//! Pure basic source metrics (LOC/blank/comment-ish) without full AST analysis.
+//! Residual pure deepen for tooling/metrics arithmetic fragment (FLEET-SITES-WAVE2).
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineKind {
+    Blank,
+    Comment,
+    Code,
+}
+
+#[must_use]
+pub fn classify_line(trimmed: &str) -> LineKind {
+    if trimmed.is_empty() {
+        return LineKind::Blank;
+    }
+    if trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with('*')
+        || trimmed.starts_with("*/")
+    {
+        return LineKind::Comment;
+    }
+    LineKind::Code
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BasicLocMetrics {
+    pub loc: usize,
+    pub blank: usize,
+    pub cloc: usize,
+    pub sloc: usize,
+}
+
+#[must_use]
+pub fn analyze_basic_loc(source: &str) -> BasicLocMetrics {
+    let lines: Vec<&str> = if source.is_empty() {
+        Vec::new()
+    } else {
+        source.split('\n').collect()
+    };
+    let loc = if source.is_empty() { 0 } else { lines.len() };
+    let mut blank = 0usize;
+    let mut cloc = 0usize;
+    for line in &lines {
+        match classify_line(line.trim()) {
+            LineKind::Blank => blank += 1,
+            LineKind::Comment => cloc += 1,
+            LineKind::Code => {}
+        }
+    }
+    let sloc = loc.saturating_sub(blank).saturating_sub(cloc);
+    BasicLocMetrics { loc, blank, cloc, sloc }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loc_blank_comment_code() {
+        let src = "fn main() {}\n\n// comment\nlet x = 1;\n";
+        let m = analyze_basic_loc(src);
+        assert!(m.loc >= 4);
+        assert!(m.blank >= 1);
+        assert!(m.cloc >= 1);
+        assert!(m.sloc >= 2);
+    }
+
+    #[test]
+    fn empty_source() {
+        let m = analyze_basic_loc("");
+        assert_eq!(m, BasicLocMetrics { loc: 0, blank: 0, cloc: 0, sloc: 0 });
+    }
+}

--- a/crates/core/src/minify_savings.rs
+++ b/crates/core/src/minify_savings.rs
@@ -1,0 +1,52 @@
+//! Pure minify savings arithmetic (parity with packages/synth-js-minify savings()).
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Savings {
+    pub original_size: usize,
+    pub minified_size: usize,
+    pub saved_bytes: isize,
+    pub saved_percent: f64,
+}
+
+#[must_use]
+pub fn savings(original: &str, minified: &str) -> Savings {
+    let original_size = original.len();
+    let minified_size = minified.len();
+    let saved_bytes = original_size as isize - minified_size as isize;
+    let saved_percent = if original_size == 0 {
+        0.0
+    } else {
+        (saved_bytes as f64 / original_size as f64) * 100.0
+    };
+    Savings { original_size, minified_size, saved_bytes, saved_percent }
+}
+
+#[must_use]
+pub fn compression_ratio(original_len: usize, minified_len: usize) -> f64 {
+    if original_len == 0 {
+        return 0.0;
+    }
+    1.0 - (minified_len as f64 / original_len as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn savings_basic() {
+        let s = savings("aaaa", "aa");
+        assert_eq!(s.original_size, 4);
+        assert_eq!(s.minified_size, 2);
+        assert_eq!(s.saved_bytes, 2);
+        assert!((s.saved_percent - 50.0).abs() < 1e-9);
+        assert!((compression_ratio(4, 2) - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn empty_original() {
+        let s = savings("", "");
+        assert_eq!(s.saved_bytes, 0);
+        assert_eq!(s.saved_percent, 0.0);
+    }
+}

--- a/crates/core/src/minify_savings.rs
+++ b/crates/core/src/minify_savings.rs
@@ -49,4 +49,21 @@ mod tests {
         assert_eq!(s.saved_bytes, 0);
         assert_eq!(s.saved_percent, 0.0);
     }
+
+    #[test]
+    fn fleet_web_media_wave4_ratio_and_zero_original() {
+        let s = savings("abcdefghij", "abcd");
+        assert_eq!(s.original_size, 10);
+        assert_eq!(s.minified_size, 4);
+        assert_eq!(s.saved_bytes, 6);
+        assert!((s.saved_percent - 60.0).abs() < 1e-9);
+        assert!((compression_ratio(10, 4) - 0.6).abs() < 1e-9);
+        let z = savings("", "x");
+        assert_eq!(z.original_size, 0);
+        assert_eq!(z.saved_percent, 0.0);
+        assert_eq!(compression_ratio(0, 5), 0.0);
+        let full = savings("same", "same");
+        assert_eq!(full.saved_bytes, 0);
+        assert!((full.saved_percent - 0.0).abs() < 1e-9);
+    }
 }

--- a/crates/core/src/position.rs
+++ b/crates/core/src/position.rs
@@ -52,3 +52,38 @@ impl Span {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fleet_web_media_wave4_position_new_and_eq() {
+        let p = Position::new(1, 0, 0);
+        assert_eq!(p.line, 1);
+        assert_eq!(p.column, 0);
+        assert_eq!(p.offset, 0);
+        assert_eq!(p, Position::new(1, 0, 0));
+        assert_ne!(p, Position::new(2, 0, 0));
+    }
+
+    #[test]
+    fn fleet_web_media_wave4_span_from_coords() {
+        let s = Span::from_coords(1, 0, 0, 2, 5, 20);
+        assert_eq!(s.start.line, 1);
+        assert_eq!(s.end.line, 2);
+        assert_eq!(s.end.column, 5);
+        assert_eq!(s.end.offset, 20);
+        let s2 = Span::new(Position::new(1, 0, 0), Position::new(1, 10, 10));
+        assert_eq!(s2.start.offset, 0);
+        assert_eq!(s2.end.column, 10);
+    }
+
+    #[test]
+    fn fleet_web_media_wave4_span_serde_roundtrip() {
+        let s = Span::from_coords(3, 1, 10, 3, 8, 17);
+        let json = serde_json::to_string(&s).expect("ser");
+        let back: Span = serde_json::from_str(&json).expect("de");
+        assert_eq!(back, s);
+    }
+}

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -1,0 +1,106 @@
+//! Pure AST query helpers (ADR-168 rust_impl for core/ast-traverse-query).
+
+use crate::tree::{Node, NodeId, Tree};
+
+/// Collect all node ids with the given `node_type` (pre-order DFS).
+#[must_use]
+pub fn find_by_type(tree: &Tree, node_type: &str) -> Vec<NodeId> {
+    let mut out = Vec::new();
+    walk_collect(tree, tree.root_id(), &mut |node| {
+        if node.node_type == node_type {
+            out.push(node.id);
+        }
+    });
+    out
+}
+
+/// Collect descendant ids of `start` (not including start), pre-order.
+#[must_use]
+pub fn descendants(tree: &Tree, start: NodeId) -> Vec<NodeId> {
+    let mut out = Vec::new();
+    let Ok(node) = tree.get_node(start) else {
+        return out;
+    };
+    for child in &node.children {
+        collect_subtree(tree, *child, &mut out);
+    }
+    out
+}
+
+/// Depth of a node from the root (root = 0). Returns None if node missing.
+#[must_use]
+pub fn depth(tree: &Tree, id: NodeId) -> Option<usize> {
+    let mut d = 0usize;
+    let mut cur = id;
+    loop {
+        let node = tree.get_node(cur).ok()?;
+        match node.parent {
+            Some(p) => {
+                d += 1;
+                cur = p;
+            }
+            None => return Some(d),
+        }
+    }
+}
+
+fn collect_subtree(tree: &Tree, id: NodeId, out: &mut Vec<NodeId>) {
+    out.push(id);
+    if let Ok(node) = tree.get_node(id) {
+        for child in &node.children.clone() {
+            collect_subtree(tree, *child, out);
+        }
+    }
+}
+
+fn walk_collect(tree: &Tree, id: NodeId, f: &mut dyn FnMut(&Node)) {
+    if let Ok(node) = tree.get_node(id) {
+        // clone children to avoid borrow issues
+        let children = node.children.clone();
+        f(node);
+        for child in children {
+            walk_collect(tree, child, f);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::{Node, Tree};
+
+    fn sample_tree() -> Tree {
+        let mut tree = Tree::new("markdown", "# hi");
+        let root = tree.root_id();
+        // ensure root typed as document if empty tree uses placeholder
+        let h = tree.add_node(Node::new(0, "heading")); // id reassigned by add_node
+        let p = tree.add_node(Node::new(0, "paragraph"));
+        let t = tree.add_node(Node::new(0, "text"));
+        let _ = tree.add_child(root, h);
+        let _ = tree.add_child(root, p);
+        let _ = tree.add_child(p, t);
+        tree
+    }
+
+    #[test]
+    fn finds_by_type() {
+        let tree = sample_tree();
+        assert_eq!(find_by_type(&tree, "text").len(), 1);
+        assert_eq!(find_by_type(&tree, "heading").len(), 1);
+    }
+
+    #[test]
+    fn descendants_of_root() {
+        let tree = sample_tree();
+        let d = descendants(&tree, tree.root_id());
+        assert_eq!(d.len(), 3);
+    }
+
+    #[test]
+    fn depth_values() {
+        let tree = sample_tree();
+        assert_eq!(depth(&tree, tree.root_id()), Some(0));
+        let texts = find_by_type(&tree, "text");
+        assert_eq!(depth(&tree, texts[0]), Some(2));
+    }
+}

--- a/crates/core/src/token_span.rs
+++ b/crates/core/src/token_span.rs
@@ -1,0 +1,110 @@
+//! Pure token span helpers + token-stats formatting — mirrors
+//! `packages/synth/src/types/token.ts` and `incremental-tokenizer.ts#formatTokenStats`.
+//! FLEET-PRODUCTS-WAVE8 pure residual. NO authority_rust / ts_deleted.
+
+/// Check if position (byte offset) is within inclusive token span [start, end].
+#[must_use]
+pub fn is_position_in_token(position: u32, start_offset: u32, end_offset: u32) -> bool {
+    position >= start_offset && position <= end_offset
+}
+
+/// Token range overlap (inclusive ends).
+#[must_use]
+pub fn token_ranges_overlap(start1: u32, end1: u32, start2: u32, end2: u32) -> bool {
+    start1 <= end2 && start2 <= end1
+}
+
+/// Binary-search token index covering `offset` in sorted (start,end) spans.
+#[must_use]
+pub fn find_token_index_at_offset(spans: &[(u32, u32)], offset: u32) -> Option<usize> {
+    if spans.is_empty() {
+        return None;
+    }
+    let mut left: isize = 0;
+    let mut right: isize = spans.len() as isize - 1;
+    while left <= right {
+        let mid = ((left + right) / 2) as usize;
+        let (start, end) = spans[mid];
+        if offset < start {
+            right = mid as isize - 1;
+        } else if offset > end {
+            left = mid as isize + 1;
+        } else {
+            return Some(mid);
+        }
+    }
+    None
+}
+
+/// Tokenizer stats for display formatting.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TokenizerStats {
+    pub total_tokens: u32,
+    pub reused_tokens: u32,
+    pub new_tokens: u32,
+    pub affected_tokens: u32,
+    pub time_ms: f64,
+    pub reuse_rate: f64,
+}
+
+/// Format token stats string (TS: formatTokenStats).
+#[must_use]
+pub fn format_token_stats(stats: &TokenizerStats) -> String {
+    format!(
+        "Total: {} tokens, Reused: {} ({:.1}%), New: {}, Affected: {}, Time: {:.2}ms",
+        stats.total_tokens,
+        stats.reused_tokens,
+        stats.reuse_rate * 100.0,
+        stats.new_tokens,
+        stats.affected_tokens,
+        stats.time_ms
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn position_in_token() {
+        assert!(is_position_in_token(5, 0, 10));
+        assert!(is_position_in_token(0, 0, 10));
+        assert!(is_position_in_token(10, 0, 10));
+        assert!(!is_position_in_token(11, 0, 10));
+    }
+
+    #[test]
+    fn ranges_overlap_inclusive() {
+        assert!(token_ranges_overlap(0, 5, 5, 10));
+        assert!(!token_ranges_overlap(0, 4, 5, 10));
+        assert!(token_ranges_overlap(0, 10, 3, 7));
+    }
+
+    #[test]
+    fn find_token_binary() {
+        let spans = [(0, 3), (4, 7), (8, 12)];
+        assert_eq!(find_token_index_at_offset(&spans, 5), Some(1));
+        assert_eq!(find_token_index_at_offset(&spans, 0), Some(0));
+        assert_eq!(find_token_index_at_offset(&spans, 12), Some(2));
+        assert_eq!(find_token_index_at_offset(&spans, 13), None);
+        assert_eq!(find_token_index_at_offset(&[], 0), None);
+    }
+
+    #[test]
+    fn format_stats() {
+        let s = TokenizerStats {
+            total_tokens: 100,
+            reused_tokens: 40,
+            new_tokens: 60,
+            affected_tokens: 10,
+            time_ms: 1.5,
+            reuse_rate: 0.4,
+        };
+        let out = format_token_stats(&s);
+        assert!(out.contains("Total: 100 tokens"));
+        assert!(out.contains("Reused: 40 (40.0%)"));
+        assert!(out.contains("New: 60"));
+        assert!(out.contains("Affected: 10"));
+        assert!(out.contains("Time: 1.50ms"));
+    }
+}

--- a/crates/core/src/traverse.rs
+++ b/crates/core/src/traverse.rs
@@ -1,0 +1,213 @@
+//! Pure AST traversal orders (ADR-168 bulk deepen for core/ast-traverse-query).
+//!
+//! Parity target: `src/core/traverse.ts` id-collection semantics (no visitor
+//! callbacks — those stay TS until a higher-level WASM bridge ships).
+
+use crate::tree::{NodeId, Tree};
+
+/// Traversal order (parity with TS `TraversalOrder`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraversalOrder {
+    PreOrder,
+    PostOrder,
+    BreadthFirst,
+}
+
+/// Collect node ids under `start` (including `start`) in the given order.
+#[must_use]
+pub fn collect_ids(tree: &Tree, start: NodeId, order: TraversalOrder) -> Vec<NodeId> {
+    let mut out = Vec::new();
+    match order {
+        TraversalOrder::PreOrder => collect_pre(tree, start, &mut out),
+        TraversalOrder::PostOrder => collect_post(tree, start, &mut out),
+        TraversalOrder::BreadthFirst => collect_bfs(tree, start, &mut out),
+    }
+    out
+}
+
+/// Pre-order walk of the whole tree from root.
+#[must_use]
+pub fn pre_order(tree: &Tree) -> Vec<NodeId> {
+    collect_ids(tree, tree.root_id(), TraversalOrder::PreOrder)
+}
+
+/// Post-order walk of the whole tree from root.
+#[must_use]
+pub fn post_order(tree: &Tree) -> Vec<NodeId> {
+    collect_ids(tree, tree.root_id(), TraversalOrder::PostOrder)
+}
+
+/// Breadth-first walk of the whole tree from root.
+#[must_use]
+pub fn breadth_first(tree: &Tree) -> Vec<NodeId> {
+    collect_ids(tree, tree.root_id(), TraversalOrder::BreadthFirst)
+}
+
+/// Collect ids with max depth bound (depth of `start` = 0). Nodes deeper than
+/// `max_depth` are omitted (parity with TS `options.maxDepth`).
+#[must_use]
+pub fn collect_ids_max_depth(
+    tree: &Tree,
+    start: NodeId,
+    order: TraversalOrder,
+    max_depth: usize,
+) -> Vec<NodeId> {
+    let mut out = Vec::new();
+    match order {
+        TraversalOrder::PreOrder => collect_pre_depth(tree, start, 0, max_depth, &mut out),
+        TraversalOrder::PostOrder => collect_post_depth(tree, start, 0, max_depth, &mut out),
+        TraversalOrder::BreadthFirst => collect_bfs_depth(tree, start, max_depth, &mut out),
+    }
+    out
+}
+
+fn children_of(tree: &Tree, id: NodeId) -> Vec<NodeId> {
+    tree.get_node(id)
+        .map(|n| n.children.clone())
+        .unwrap_or_default()
+}
+
+fn collect_pre(tree: &Tree, id: NodeId, out: &mut Vec<NodeId>) {
+    if tree.get_node(id).is_err() {
+        return;
+    }
+    out.push(id);
+    for child in children_of(tree, id) {
+        collect_pre(tree, child, out);
+    }
+}
+
+fn collect_post(tree: &Tree, id: NodeId, out: &mut Vec<NodeId>) {
+    if tree.get_node(id).is_err() {
+        return;
+    }
+    for child in children_of(tree, id) {
+        collect_post(tree, child, out);
+    }
+    out.push(id);
+}
+
+fn collect_bfs(tree: &Tree, start: NodeId, out: &mut Vec<NodeId>) {
+    if tree.get_node(start).is_err() {
+        return;
+    }
+    let mut queue = std::collections::VecDeque::from([start]);
+    while let Some(id) = queue.pop_front() {
+        out.push(id);
+        for child in children_of(tree, id) {
+            queue.push_back(child);
+        }
+    }
+}
+
+fn collect_pre_depth(
+    tree: &Tree,
+    id: NodeId,
+    depth: usize,
+    max_depth: usize,
+    out: &mut Vec<NodeId>,
+) {
+    if depth > max_depth || tree.get_node(id).is_err() {
+        return;
+    }
+    out.push(id);
+    for child in children_of(tree, id) {
+        collect_pre_depth(tree, child, depth + 1, max_depth, out);
+    }
+}
+
+fn collect_post_depth(
+    tree: &Tree,
+    id: NodeId,
+    depth: usize,
+    max_depth: usize,
+    out: &mut Vec<NodeId>,
+) {
+    if depth > max_depth || tree.get_node(id).is_err() {
+        return;
+    }
+    for child in children_of(tree, id) {
+        collect_post_depth(tree, child, depth + 1, max_depth, out);
+    }
+    out.push(id);
+}
+
+fn collect_bfs_depth(tree: &Tree, start: NodeId, max_depth: usize, out: &mut Vec<NodeId>) {
+    if tree.get_node(start).is_err() {
+        return;
+    }
+    let mut queue = std::collections::VecDeque::from([(start, 0usize)]);
+    while let Some((id, depth)) = queue.pop_front() {
+        if depth > max_depth {
+            continue;
+        }
+        out.push(id);
+        for child in children_of(tree, id) {
+            queue.push_back((child, depth + 1));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::{Node, Tree};
+
+    fn sample() -> Tree {
+        let mut tree = Tree::new("markdown", "# hi");
+        let root = tree.root_id();
+        let h = tree.add_node(Node::new(0, "heading"));
+        let p = tree.add_node(Node::new(0, "paragraph"));
+        let t = tree.add_node(Node::new(0, "text"));
+        let _ = tree.add_child(root, h);
+        let _ = tree.add_child(root, p);
+        let _ = tree.add_child(p, t);
+        tree
+    }
+
+    #[test]
+    fn pre_order_root_first() {
+        let tree = sample();
+        let ids = pre_order(&tree);
+        assert_eq!(ids[0], tree.root_id());
+        assert_eq!(ids.len(), 4);
+    }
+
+    #[test]
+    fn post_order_root_last() {
+        let tree = sample();
+        let ids = post_order(&tree);
+        assert_eq!(*ids.last().unwrap(), tree.root_id());
+        assert_eq!(ids.len(), 4);
+    }
+
+    #[test]
+    fn bfs_levels() {
+        let tree = sample();
+        let ids = breadth_first(&tree);
+        assert_eq!(ids[0], tree.root_id());
+        // children of root appear before grandchild
+        let p = tree
+            .nodes()
+            .iter()
+            .find(|n| n.node_type == "paragraph")
+            .unwrap()
+            .id;
+        let t = tree
+            .nodes()
+            .iter()
+            .find(|n| n.node_type == "text")
+            .unwrap()
+            .id;
+        let pi = ids.iter().position(|&x| x == p).unwrap();
+        let ti = ids.iter().position(|&x| x == t).unwrap();
+        assert!(pi < ti);
+    }
+
+    #[test]
+    fn max_depth_zero_is_root_only() {
+        let tree = sample();
+        let ids = collect_ids_max_depth(&tree, tree.root_id(), TraversalOrder::PreOrder, 0);
+        assert_eq!(ids, vec![tree.root_id()]);
+    }
+}

--- a/crates/core/src/zipper.rs
+++ b/crates/core/src/zipper.rs
@@ -1,0 +1,191 @@
+//! Pure zipper navigation over arena trees (ADR-168 bulk for core/ast-traverse-query).
+//!
+//! Parity target: `src/core/zipper.ts` navigation helpers (focus / up / down / left / right).
+//! Mutating edit operations remain TS until a full WASM edit surface lands.
+
+use crate::tree::{NodeId, Tree};
+
+/// Breadcrumb for one step from root toward focus.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Crumb {
+    pub parent_id: NodeId,
+    pub index: usize,
+    pub left: Vec<NodeId>,
+    pub right: Vec<NodeId>,
+}
+
+/// Zipper focused on a single node with a path back to the root.
+#[derive(Debug, Clone)]
+pub struct Zipper {
+    pub focus: NodeId,
+    pub path: Vec<Crumb>,
+}
+
+/// Create a zipper focused on the tree root.
+#[must_use]
+pub fn create_zipper(tree: &Tree) -> Zipper {
+    Zipper {
+        focus: tree.root_id(),
+        path: Vec::new(),
+    }
+}
+
+/// Create a zipper focused on `node_id`, or `None` if the node is missing / disconnected.
+#[must_use]
+pub fn create_zipper_at(tree: &Tree, node_id: NodeId) -> Option<Zipper> {
+    let node = tree.get_node(node_id).ok()?;
+    let mut path: Vec<Crumb> = Vec::new();
+    let mut current_id = node_id;
+    let mut current_parent = node.parent;
+
+    while let Some(parent_id) = current_parent {
+        let parent = tree.get_node(parent_id).ok()?;
+        let index = parent.children.iter().position(|&c| c == current_id)?;
+        path.insert(
+            0,
+            Crumb {
+                parent_id,
+                index,
+                left: parent.children[..index].to_vec(),
+                right: parent.children[index + 1..].to_vec(),
+            },
+        );
+        current_id = parent_id;
+        current_parent = parent.parent;
+    }
+
+    Some(Zipper {
+        focus: node_id,
+        path,
+    })
+}
+
+/// Move focus to the first child, if any.
+#[must_use]
+pub fn down(tree: &Tree, z: &Zipper) -> Option<Zipper> {
+    let node = tree.get_node(z.focus).ok()?;
+    let first = *node.children.first()?;
+    let mut path = z.path.clone();
+    path.push(Crumb {
+        parent_id: z.focus,
+        index: 0,
+        left: Vec::new(),
+        right: node.children[1..].to_vec(),
+    });
+    Some(Zipper { focus: first, path })
+}
+
+/// Move focus to the parent, if any.
+#[must_use]
+pub fn up(z: &Zipper) -> Option<Zipper> {
+    let mut path = z.path.clone();
+    let crumb = path.pop()?;
+    Some(Zipper {
+        focus: crumb.parent_id,
+        path,
+    })
+}
+
+/// Move focus to the previous sibling, if any.
+#[must_use]
+pub fn left(z: &Zipper) -> Option<Zipper> {
+    let mut path = z.path.clone();
+    let crumb = path.last_mut()?;
+    let prev = *crumb.left.last()?;
+    crumb.left.pop();
+    let old_focus = z.focus;
+    crumb.right.insert(0, old_focus);
+    crumb.index = crumb.index.saturating_sub(1);
+    Some(Zipper {
+        focus: prev,
+        path,
+    })
+}
+
+/// Move focus to the next sibling, if any.
+#[must_use]
+pub fn right(z: &Zipper) -> Option<Zipper> {
+    let mut path = z.path.clone();
+    let crumb = path.last_mut()?;
+    let next = *crumb.right.first()?;
+    crumb.right.remove(0);
+    let old_focus = z.focus;
+    crumb.left.push(old_focus);
+    crumb.index += 1;
+    Some(Zipper {
+        focus: next,
+        path,
+    })
+}
+
+/// Depth of the focus (root = 0).
+#[must_use]
+pub fn zipper_depth(z: &Zipper) -> usize {
+    z.path.len()
+}
+
+/// True when focus is the root.
+#[must_use]
+pub fn is_root(z: &Zipper) -> bool {
+    z.path.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree::{Node, Tree};
+
+    fn sample() -> Tree {
+        let mut tree = Tree::new("markdown", "x");
+        let root = tree.root_id();
+        let a = tree.add_node(Node::new(0, "a"));
+        let b = tree.add_node(Node::new(0, "b"));
+        let c = tree.add_node(Node::new(0, "c"));
+        let _ = tree.add_child(root, a);
+        let _ = tree.add_child(root, b);
+        let _ = tree.add_child(a, c);
+        tree
+    }
+
+    #[test]
+    fn root_zipper() {
+        let tree = sample();
+        let z = create_zipper(&tree);
+        assert!(is_root(&z));
+        assert_eq!(zipper_depth(&z), 0);
+    }
+
+    #[test]
+    fn down_up_roundtrip() {
+        let tree = sample();
+        let z = create_zipper(&tree);
+        let child = down(&tree, &z).expect("has child");
+        assert!(!is_root(&child));
+        let back = up(&child).expect("up");
+        assert_eq!(back.focus, tree.root_id());
+    }
+
+    #[test]
+    fn left_right_siblings() {
+        let tree = sample();
+        let z = create_zipper(&tree);
+        let first = down(&tree, &z).unwrap();
+        let second = right(&first).unwrap();
+        let back = left(&second).unwrap();
+        assert_eq!(back.focus, first.focus);
+    }
+
+    #[test]
+    fn create_at_nested() {
+        let tree = sample();
+        let c = tree
+            .nodes()
+            .iter()
+            .find(|n| n.node_type == "c")
+            .unwrap()
+            .id;
+        let z = create_zipper_at(&tree, c).unwrap();
+        assert_eq!(z.focus, c);
+        assert_eq!(zipper_depth(&z), 2);
+    }
+}

--- a/crates/core/tests/incremental_batch_golden.rs
+++ b/crates/core/tests/incremental_batch_golden.rs
@@ -1,0 +1,231 @@
+//! Golden fixture: incremental + batch pure residual (BW1 deepen).
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use synth_wasm_core::{
+    batch_preorder_ids, calculate_affected_range, chunk_ids, find_affected_nodes,
+    find_node_at_offset, group_node_ids_by_type, normalize_simple_edit, offset_to_position,
+    plan_batches, plan_edits, ranges_overlap, set_node_span, BatchProcessingOptions, Node,
+    Position, SimpleEdit, Span, Tree,
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Fixture {
+    language: String,
+    source_text: String,
+    nodes: Vec<NodeSpec>,
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NodeSpec {
+    id: u32,
+    #[serde(rename = "type")]
+    node_type: String,
+    #[allow(dead_code)]
+    parent: Option<u32>,
+    children: Vec<u32>,
+    span: Option<SpanSpec>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpanSpec {
+    start: PosSpec,
+    end: PosSpec,
+}
+
+#[derive(Debug, Deserialize)]
+struct PosSpec {
+    line: u32,
+    column: u32,
+    offset: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Case {
+    name: String,
+    kind: String,
+    a: Option<[u32; 2]>,
+    b: Option<[u32; 2]>,
+    expected: Option<bool>,
+    offset: Option<u32>,
+    expected_position: Option<PosSpec>,
+    simple_edits: Option<Vec<SimpleEditSpec>>,
+    expected_affected_ids: Option<Vec<u32>>,
+    expected_range: Option<RangeSpec>,
+    expected_id: Option<u32>,
+    expected_ids: Option<Vec<u32>>,
+    #[serde(rename = "type")]
+    type_name: Option<String>,
+    batch_size: Option<usize>,
+    expected_batches: Option<Vec<Vec<u32>>>,
+    group_by_type: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SimpleEditSpec {
+    start: u32,
+    old_length: u32,
+    new_length: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RangeSpec {
+    start_byte: u32,
+    end_byte: u32,
+}
+
+fn load_tree(fx: &Fixture) -> Tree {
+    let mut tree = Tree::new(&fx.language, &fx.source_text);
+    assert_eq!(fx.nodes[0].id, 0);
+    for spec in fx.nodes.iter().skip(1) {
+        let id = tree.add_node(Node::new(0, &spec.node_type));
+        assert_eq!(id, spec.id);
+    }
+    for spec in &fx.nodes {
+        for &child in &spec.children {
+            tree.add_child(spec.id, child).expect("child");
+        }
+        if let Some(span) = &spec.span {
+            set_node_span(
+                &mut tree,
+                spec.id,
+                Span::new(
+                    Position::new(span.start.line, span.start.column, span.start.offset),
+                    Position::new(span.end.line, span.end.column, span.end.offset),
+                ),
+            );
+        }
+    }
+    tree
+}
+
+#[test]
+fn incremental_batch_golden_fixture() {
+    let path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/incremental_batch_golden.json");
+    let raw = std::fs::read_to_string(&path).expect("read fixture");
+    let fx: Fixture = serde_json::from_str(&raw).expect("parse fixture");
+    let tree = load_tree(&fx);
+
+    for case in &fx.cases {
+        match case.kind.as_str() {
+            "ranges_overlap" => {
+                let a = case.a.unwrap();
+                let b = case.b.unwrap();
+                let got = ranges_overlap(a[0], a[1], b[0], b[1]);
+                assert_eq!(got, case.expected.unwrap(), "{}", case.name);
+            }
+            "offset_to_position" => {
+                let p = offset_to_position(&fx.source_text, case.offset.unwrap());
+                let exp = case.expected_position.as_ref().unwrap();
+                assert_eq!(p.line, exp.line, "{}", case.name);
+                assert_eq!(p.column, exp.column, "{}", case.name);
+                assert_eq!(p.offset, exp.offset, "{}", case.name);
+            }
+            "plan_edits" => {
+                let simple: Vec<SimpleEdit> = case
+                    .simple_edits
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .map(|s| SimpleEdit {
+                        start: s.start,
+                        old_length: s.old_length,
+                        new_length: s.new_length,
+                    })
+                    .collect();
+                let (_edits, affected, range) = plan_edits(&tree, &simple);
+                assert_eq!(
+                    affected,
+                    case.expected_affected_ids.clone().unwrap(),
+                    "{}",
+                    case.name
+                );
+                let er = case.expected_range.as_ref().unwrap();
+                assert_eq!(range.start_byte, er.start_byte, "{}", case.name);
+                assert_eq!(range.end_byte, er.end_byte, "{}", case.name);
+                // also exercise discrete helpers
+                let edits: Vec<_> = simple
+                    .iter()
+                    .copied()
+                    .map(|s| normalize_simple_edit(&fx.source_text, s))
+                    .collect();
+                assert_eq!(find_affected_nodes(&tree, &edits), affected);
+                let r2 = calculate_affected_range(&edits);
+                assert_eq!(r2.start_byte, range.start_byte);
+            }
+            "find_node_at_offset" => {
+                let id = find_node_at_offset(&tree, case.offset.unwrap());
+                assert_eq!(id, case.expected_id, "{}", case.name);
+            }
+            "batch_preorder" => {
+                let ids = batch_preorder_ids(&tree);
+                assert_eq!(ids, case.expected_ids.clone().unwrap(), "{}", case.name);
+            }
+            "group_by_type" => {
+                let ids = batch_preorder_ids(&tree);
+                let grouped: BTreeMap<_, _> = group_node_ids_by_type(&tree, &ids);
+                let got = grouped
+                    .get(case.type_name.as_deref().unwrap())
+                    .cloned()
+                    .unwrap_or_default();
+                assert_eq!(got, case.expected_ids.clone().unwrap(), "{}", case.name);
+            }
+            "chunk" => {
+                let ids = batch_preorder_ids(&tree);
+                let batches = chunk_ids(&ids, case.batch_size.unwrap());
+                assert_eq!(
+                    batches,
+                    case.expected_batches.clone().unwrap(),
+                    "{}",
+                    case.name
+                );
+            }
+            "find_overlapping_only" => {
+                let simple: Vec<SimpleEdit> = case
+                    .simple_edits
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .map(|s| SimpleEdit {
+                        start: s.start,
+                        old_length: s.old_length,
+                        new_length: s.new_length,
+                    })
+                    .collect();
+                let (_edits, affected, _range) = plan_edits(&tree, &simple);
+                assert_eq!(
+                    affected,
+                    case.expected_affected_ids.clone().unwrap(),
+                    "{}",
+                    case.name
+                );
+            }
+            "plan_batches" => {
+                let ids = batch_preorder_ids(&tree);
+                let plans = plan_batches(
+                    &tree,
+                    &ids,
+                    BatchProcessingOptions {
+                        batch_size: case.batch_size.unwrap(),
+                        group_by_type: case.group_by_type.unwrap_or(true),
+                    },
+                );
+                let batches: Vec<Vec<u32>> = plans.into_iter().map(|(_, b)| b).collect();
+                assert_eq!(
+                    batches,
+                    case.expected_batches.clone().unwrap(),
+                    "{}",
+                    case.name
+                );
+            }
+            other => panic!("unknown kind {other}"),
+        }
+    }
+}

--- a/crates/core/tests/traverse_golden.rs
+++ b/crates/core/tests/traverse_golden.rs
@@ -1,0 +1,104 @@
+//! Golden fixture: traverse / query pure residual (BW1).
+
+use serde::Deserialize;
+use std::path::PathBuf;
+use synth_wasm_core::{
+    collect_ids, collect_ids_max_depth, depth, descendants, find_by_type, Node, TraversalOrder, Tree,
+};
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    language: String,
+    #[serde(rename = "sourceText")]
+    source_text: String,
+    nodes: Vec<NodeSpec>,
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NodeSpec {
+    id: u32,
+    #[serde(rename = "type")]
+    node_type: String,
+    parent: Option<u32>,
+    children: Vec<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Case {
+    name: String,
+    order: Option<String>,
+    max_depth: Option<usize>,
+    query: Option<String>,
+    #[serde(rename = "type")]
+    type_name: Option<String>,
+    start: Option<u32>,
+    expected_ids: Option<Vec<u32>>,
+    expected_depth: Option<usize>,
+}
+
+fn load_tree(fx: &Fixture) -> Tree {
+    // Build tree matching fixture ids by adding nodes in order after root.
+    let mut tree = Tree::new(&fx.language, &fx.source_text);
+    // Root is always 0 from Tree::new — verify fixture root matches
+    assert_eq!(fx.nodes[0].id, 0);
+    // Add remaining nodes
+    for spec in fx.nodes.iter().skip(1) {
+        let id = tree.add_node(Node::new(0, &spec.node_type));
+        assert_eq!(id, spec.id, "fixture id order must match arena order");
+    }
+    // Wire parent/children from fixture (skip root children re-add if already empty)
+    for spec in &fx.nodes {
+        if let Some(parent) = spec.parent {
+            // child already has parent set via add_child below
+            let _ = parent;
+        }
+        for &child in &spec.children {
+            tree.add_child(spec.id, child).expect("child link");
+        }
+    }
+    tree
+}
+
+#[test]
+fn traverse_golden_fixture() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/traverse_golden.json");
+    let raw = std::fs::read_to_string(&path).expect("read fixture");
+    let fx: Fixture = serde_json::from_str(&raw).expect("parse fixture");
+    let tree = load_tree(&fx);
+
+    for case in &fx.cases {
+        if let Some(query) = &case.query {
+            match query.as_str() {
+                "find_by_type" => {
+                    let ids = find_by_type(&tree, case.type_name.as_deref().unwrap());
+                    assert_eq!(ids, case.expected_ids.clone().unwrap(), "{}", case.name);
+                }
+                "descendants" => {
+                    let ids = descendants(&tree, case.start.unwrap());
+                    assert_eq!(ids, case.expected_ids.clone().unwrap(), "{}", case.name);
+                }
+                "depth" => {
+                    let d = depth(&tree, case.start.unwrap());
+                    assert_eq!(d, case.expected_depth, "{}", case.name);
+                }
+                other => panic!("unknown query {other}"),
+            }
+            continue;
+        }
+
+        let order = match case.order.as_deref() {
+            Some("pre") => TraversalOrder::PreOrder,
+            Some("post") => TraversalOrder::PostOrder,
+            Some("bfs") => TraversalOrder::BreadthFirst,
+            other => panic!("unknown order {other:?}"),
+        };
+        let ids = if let Some(md) = case.max_depth {
+            collect_ids_max_depth(&tree, tree.root_id(), order, md)
+        } else {
+            collect_ids(&tree, tree.root_id(), order)
+        };
+        assert_eq!(ids, case.expected_ids.clone().unwrap(), "{}", case.name);
+    }
+}

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -193,8 +193,8 @@
     "weighted_progress": 0.1346,
     "proof_stale": 3,
     "proof_missing": 2,
-    "updatedAt": "2026-07-11T14:04:33Z",
-    "lastMutation": "PROOF-GAP-58-WAVE-TICK026",
+    "updatedAt": "2026-07-13T01:10:50Z",
+    "lastMutation": "FLEET-WEB-MEDIA-WAVE4",
     "verified_authority_progress": 0.0
   },
   "repoLedgerPath": "docs/specs/migration-ledger.json",
@@ -219,5 +219,22 @@
       }
     ],
     "policy": "demote incomplete promoted states to rust_impl; no authority_rust/ts_deleted promotions"
+  },
+  "honestyResidual": {
+    "packet": "FLEET-WEB-MEDIA-WAVE4",
+    "at": "2026-07-13T01:10:50Z",
+    "authority_rust": false,
+    "ts_deleted": false,
+    "goal_complete": false,
+    "strongestTruthfulState": "rust_impl_minority_proof_missing_or_stale_offline",
+    "explicitNonClaims": [
+      "authority_rust",
+      "ts_deleted",
+      "parity_proven",
+      "differential_green",
+      "canary_green",
+      "REPO_COMPLETE",
+      "fleet FCP"
+    ]
   }
 }

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -59,7 +59,13 @@
       "weight": 5,
       "state": "rust_impl",
       "tsSurface": "packages/synth/src/traverse.ts; packages/synth/src/query-index.ts; packages/synth/src/zipper.ts; src/core/",
-      "notes": "Universal AST substrate and query engine remain TypeScript; Rust core crate provides WASM tree types only. TICK039: find_by_type/descendants/depth pure query core."
+      "rustSurface": "crates/core/src/query.rs; crates/core/src/traverse.rs; crates/core/src/zipper.rs; crates/core/fixtures/traverse_golden.json",
+      "parityTest": "crates/core/tests/traverse_golden.rs; cargo test -p synth-wasm-core",
+      "proof": {
+        "status": "missing",
+        "staleReason": "BW1 pure bulk: traverse/zipper/query unit+golden on disk — awaiting SHA-bound differential_green vs TS oracle"
+      },
+      "notes": "BW1 pure bulk deepen: pre/post/bfs collect_ids, max_depth, zipper nav, golden fixture. TS substrate retained (no ts_deleted/authority). proof missing."
     },
     {
       "id": "core/incremental-batch",

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -57,9 +57,9 @@
       "id": "core/ast-traverse-query",
       "domain": "core",
       "weight": 5,
-      "state": "ts_only",
+      "state": "rust_impl",
       "tsSurface": "packages/synth/src/traverse.ts; packages/synth/src/query-index.ts; packages/synth/src/zipper.ts; src/core/",
-      "notes": "Universal AST substrate and query engine remain TypeScript; Rust core crate provides WASM tree types only."
+      "notes": "Universal AST substrate and query engine remain TypeScript; Rust core crate provides WASM tree types only. TICK039: find_by_type/descendants/depth pure query core."
     },
     {
       "id": "core/incremental-batch",
@@ -169,9 +169,9 @@
   ],
   "summary": {
     "total": 10,
-    "ts_only": 7,
+    "ts_only": 6,
     "contracted": 0,
-    "rust_impl": 3,
+    "rust_impl": 4,
     "parity_proven": 0,
     "authority_rust": 0,
     "ts_deleted": 0,

--- a/docs/specs/migration-ledger.json
+++ b/docs/specs/migration-ledger.json
@@ -63,7 +63,7 @@
       "parityTest": "crates/core/tests/traverse_golden.rs; cargo test -p synth-wasm-core",
       "proof": {
         "status": "missing",
-        "staleReason": "BW1 pure bulk: traverse/zipper/query unit+golden on disk — awaiting SHA-bound differential_green vs TS oracle"
+        "staleReason": "BW1 pure bulk: traverse/zipper/query unit+golden on disk \u2014 awaiting SHA-bound differential_green vs TS oracle"
       },
       "notes": "BW1 pure bulk deepen: pre/post/bfs collect_ids, max_depth, zipper nav, golden fixture. TS substrate retained (no ts_deleted/authority). proof missing."
     },
@@ -71,8 +71,15 @@
       "id": "core/incremental-batch",
       "domain": "core",
       "weight": 4,
-      "state": "ts_only",
-      "tsSurface": "packages/synth/src/incremental.ts; packages/synth/src/batch-processor.ts; packages/synth/src/node-pool.ts"
+      "state": "rust_impl",
+      "tsSurface": "packages/synth/src/incremental.ts; packages/synth/src/batch-processor.ts; packages/synth/src/node-pool.ts",
+      "rustSurface": "crates/core/src/incremental.rs; crates/core/src/batch.rs; crates/core/fixtures/incremental_batch_golden.json",
+      "parityTest": "crates/core/tests/incremental_batch_golden.rs; cargo test -p synth-wasm-core",
+      "proof": {
+        "status": "missing",
+        "staleReason": "BW1 residual pure deepen: incremental edit geometry + batch chunk/group unit+golden; differential_green unbound; reparse/parser callback still TS"
+      },
+      "notes": "BW1 residual pure deepen: ranges_overlap, offset_to_position, normalize/plan_edits, find_affected_nodes (overlap+parents), calculate_affected_range, batch group/chunk/preorder plan. node-pool + reparseAffected stay TS. No authority_rust/ts_deleted."
     },
     {
       "id": "parser/javascript-wasm",
@@ -175,19 +182,20 @@
   ],
   "summary": {
     "total": 10,
-    "ts_only": 6,
+    "ts_only": 5,
     "contracted": 0,
-    "rust_impl": 4,
+    "rust_impl": 5,
     "parity_proven": 0,
     "authority_rust": 0,
     "ts_deleted": 0,
     "completion_progress": 0.0,
-    "authority_progress": 0.3,
-    "weighted_progress": 0.2462,
+    "authority_progress": 0.0,
+    "weighted_progress": 0.1346,
     "proof_stale": 3,
-    "proof_missing": 7,
+    "proof_missing": 2,
     "updatedAt": "2026-07-11T14:04:33Z",
-    "lastMutation": "PROOF-GAP-58-WAVE-TICK026"
+    "lastMutation": "PROOF-GAP-58-WAVE-TICK026",
+    "verified_authority_progress": 0.0
   },
   "repoLedgerPath": "docs/specs/migration-ledger.json",
   "rej010HonestyDemote": {


### PR DESCRIPTION
## Summary
Fleet bulk offline pure residual slice (kyle-codex-remote `fleet-bulk-residual-v*`).

- Pure Rust cores + unit tests only
- No production route flip; no authority_rust/ts_deleted cutover in this PR
- Safe independent land relative to live cutover

## Merge
Enqueue via merge queue: `gh pr merge --auto --squash`.
