### PR TITLE
ci: remove GroundAtlas package dogfood (CP ADR-0014)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           bun-version: 1.3.3
 
-      - name: Set up Node.js for GroundAtlas
         uses: actions/setup-node@v5
         with:
           node-version: "22.14.0"
@@ -89,18 +88,11 @@ jobs:
       - name: Test project-control boundary
         run: node --test test/project-control.node-test.mjs test/check-no-ts-parser.node-test.mjs test/check-no-ts-js-parser.node-test.mjs test/javascript-parity-golden.node-test.mjs
 
-      - name: GroundAtlas package dogfood
-        id: groundatlas
-        uses: SylphxAI/groundatlas@v0.1.3
         with:
-          package-spec: groundatlas@0.1.3
-          output-dir: .groundatlas-pilot
           require-atlas: "true"
           strict: "true"
 
-      - name: Assert GroundAtlas truth boundary
         run: |
-          node - "${{ steps.groundatlas.outputs.manifest-report-path }}" "${{ steps.groundatlas.outputs.fleet-report-path }}" "${{ steps.groundatlas.outputs.fleet-markdown-report-path }}" <<'NODE'
           const [manifestPath, fleetPath, fleetMarkdownPath] = process.argv.slice(2);
           const { readFileSync } = require("node:fs");
           const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
@@ -112,26 +104,16 @@ jobs:
             if (!condition) throw new Error(message);
           }
 
-          assert(manifest.selected?.path === "project.manifest.json", "GroundAtlas must select the vendor-neutral project.manifest.json file.");
-          assert(manifest.selected?.adapter === false, "Selected GroundAtlas manifest must not be a vendor adapter.");
-          assert(manifest.selected?.projectId === "synth", "GroundAtlas selected the wrong project id.");
           assert(project?.status === "adopted", "Fleet report must mark Synth adopted.");
-          assert(project?.generatedAtlas?.ok === true, "Generated GroundAtlas evidence must match the current scan.");
           assert(project?.manifest?.path === "project.manifest.json", "Fleet report must use project.manifest.json as the manifest.");
           assert(project?.manifestAdapters?.some((adapter) => adapter.path === ".doctrine/project.json" && adapter.adapter === true), "Fleet report must keep .doctrine/project.json as an adapter.");
-          assert(fleetMarkdown.includes("# GroundAtlas fleet adoption report"), "Markdown fleet scorecard must include the report title.");
           assert(fleetMarkdown.includes("Summary: 1 adopted, 0 warning, 0 blocked, 1 total."), "Markdown fleet scorecard must include the adopted summary.");
           NODE
 
-      - name: Upload GroundAtlas reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: groundatlas-package-dogfood
           path: |
-            ${{ steps.groundatlas.outputs.manifest-report-path }}
-            ${{ steps.groundatlas.outputs.fleet-report-path }}
-            ${{ steps.groundatlas.outputs.fleet-markdown-report-path }}
 
   trunk-admission:
     name: trunk-admission/pass

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,8 @@ npm exec --yes --package groundatlas@0.1.3 -- ga fleet . --out .groundatlas-pilo
 
 - Prefer the **narrowest** affected check before full workspace runs.
 - Report layers honestly: local diff · trunk FF · deploy · prod proof (do not collapse).
+
+
+## GroundAtlas
+
+GroundAtlas package dogfood is **retired** (Control Plane ADR-0014). Do not re-add required groundatlas CI jobs.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -62,3 +62,8 @@ behavior to private parser modules.
 
 Pull requests target `main` and pass ADR-29 admission contexts before merge.
 Pull requests and merge groups run `.github/workflows/ci.yml`, including ADR-29 classification/fan-in contexts, isolated Rust setup, `bun run validate`, project-control boundary tests, and GroundAtlas package dogfooding. Main pushes run postsubmit proof and recovery-decision wiring plus `.github/workflows/release.yml` for Changesets release PRs or package publication; the release build bootstraps Rust when needed, installs the Rust WASM target and `wasm-pack`, and then builds Synth WASM packages. Published package changes require Release workflow evidence and npm registry readback. Generated `.groundatlas*` files plus GroundAtlas JSON/Markdown reports are evidence/navigation only, not source of truth.
+
+
+## GroundAtlas
+
+GroundAtlas package dogfood is **retired** (Control Plane ADR-0014). Do not re-add required groundatlas CI jobs.

--- a/README.md
+++ b/README.md
@@ -139,3 +139,8 @@ MIT
 <div align="center">
   <sub>Powered by Sylphx · Built with <a href="https://www.npmjs.com/package/@sylphx/biome-config">biome-config</a> · <a href="https://www.npmjs.com/package/@sylphx/tsconfig">tsconfig</a> · <a href="https://www.npmjs.com/package/Changesets">bump</a></sub>
 </div>
+
+
+## GroundAtlas
+
+GroundAtlas package dogfood is **retired** (Control Plane ADR-0014). Do not re-add required groundatlas CI jobs.


### PR DESCRIPTION
Agent-Author: implementer

## Summary
- Remove required GroundAtlas CI dogfood job/action.
- Align with Control Plane ADR-0014 Repository Ingestion.

## Test plan
- [ ] CI green without groundatlas job
