### PR TITLE
test: retire brittle source-shape gates

### DIFF
--- a/scripts/check-no-ts-js-parser.sh
+++ b/scripts/check-no-ts-js-parser.sh
@@ -2,6 +2,8 @@
 # ADR-168 S4 gate: @sylphx/synth-js default parse()/parseAsync() must route to Rust WASM.
 # Allowed: TS JSParser for explicit opt-in (plugins, useTsParser, SYNTH_JS_AUTHORITY=ts).
 # Forbidden: unconditional TS fallback on baseline default options.
+# Temporary: delete after JS parsing is ts_deleted, exact-candidate WASM parity
+# and package install smoke are green, and registry readback binds the artifact.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/check-no-ts-parser.sh
+++ b/scripts/check-no-ts-parser.sh
@@ -2,6 +2,8 @@
 # ADR-168 S3 gate: @sylphx/synth-md default parse()/parseAsync() must route to Rust WASM.
 # Allowed: TS Parser class for explicit opt-in (plugins, batch tokenizer, useTsParser, SYNTH_MD_AUTHORITY=ts).
 # Forbidden: unconditional TS fallback on baseline default options.
+# Temporary: delete after Markdown parsing is ts_deleted, exact-candidate WASM
+# parity and package install smoke are green, and registry readback binds it.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
Agent-Author: codex\n\nRemoves brittle source-shape checks where executable behavior or artifact proof already owns the claim. Incomplete migration fences remain temporary and now carry an exact retirement predicate. No replacement lint or new CI lane is added.