### PR TITLE
feat(ci): migrate to Agent-native Fast Trunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Fast Trunk: supersede obsolete runs for the same PR or branch tip.
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   risk-classification:
     name: risk-classification/pass
@@ -91,8 +96,8 @@ jobs:
       - name: Test JavaScript parity
         run: node --test test/javascript-parity-golden.node-test.mjs
 
-  trunk-admission:
-    name: trunk-admission/pass
+  source-ci:
+    name: source-ci/pass
     runs-on: [self-hosted, sylphx, linux, standard]
     needs:
       - risk-classification
@@ -112,7 +117,7 @@ jobs:
     needs:
       - risk-classification
       - ci
-      - trunk-admission
+      - source-ci
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled() }}
     steps:
       - name: ADR-29 postsubmit proof
@@ -128,7 +133,7 @@ jobs:
     needs:
       - risk-classification
       - ci
-      - trunk-admission
+      - source-ci
       - postsubmit-proof
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.postsubmit-proof.result != 'success' }}
     steps:

--- a/docs/reference/fast-trunk-ci.md
+++ b/docs/reference/fast-trunk-ci.md
@@ -1,0 +1,23 @@
+# Fast Trunk CI
+
+## Authority split
+
+| Concern | Owner |
+| --- | --- |
+| Work / claim / review | Enact |
+| Source history | Git |
+| Source correctness | This repository CI (`source-ci/pass`) |
+| Production artifact build | Sylphx Platform (once) |
+| Deploy / health / rollback | Sylphx Platform |
+
+## Paths
+
+- **Internal agents:** small-batch non-force direct-trunk to default branch.
+- **External contributors:** Pull Request presubmit feedback.
+- **Merge Queue:** default off (no `merge_group` trigger).
+
+## CI scope
+
+Blocking: lint/typecheck, affected tests, schema/migration safety, narrow security.
+
+Not in source CI: production Docker/release image builds, disposable ship binaries for ordinary tips.


### PR DESCRIPTION
## Summary
Fleet Fast Trunk migration:
- `source-ci/pass` aggregate where trunk-admission existed
- cancel-in-progress concurrency by PR/ref
- no merge_group (MQ off)
- docs: CI=source, Platform=build once

## Test plan
- [ ] CI workflow admits
- [ ] source-ci/pass (or equivalent) published when applicable
